### PR TITLE
Player registration, expandable cards, and session modal

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,11 +4,14 @@ let newOnly = false;
 let coopOnly = false;
 let renderedGames = [];
 
-// Players
+// Player Vault (permanent registry)
 const AVATAR_COLORS = ['#e05252','#f5a842','#5dd67a','#52a8e0','#c275e0','#e91e8c','#f5c842'];
 const AVATAR_EMOJIS = ['🎮','🎲','🃏','🧩','♟️','🎯','🎪','🦁','🐉','🦊','🐺','🦝','🎭','🤖','👾','🧙','🧝','🧛','🎩','⚔️','🏴‍☠️','🐸','🐧','🦄'];
-let players = JSON.parse(localStorage.getItem('sz-players') || '[]');
-let emojiPickerTarget = null;
+let vault = JSON.parse(localStorage.getItem('sz-vault') || '[]');
+let emojiPickerTarget = null; // vault player id
+
+// Roll Call (who's playing tonight — session state)
+let rollCall = new Set();
 
 // Session
 let sessionGame = null;
@@ -22,62 +25,115 @@ fetch("games.json")
   .then(data => { games = data; })
   .catch(() => console.error("Could not load games.json"));
 
-renderPlayers();
+renderRollCall();
 
-// ── Player Registration ────────────────────────────────────────────────────
-function addPlayerFromInput() {
-  const input = document.getElementById('player-name-input');
+// ── Player Vault ───────────────────────────────────────────────────────────
+function openVault() {
+  renderVaultList();
+  document.getElementById('vault-modal').classList.add('active');
+  document.getElementById('vault-name-input').focus();
+}
+
+function closeVault() {
+  document.getElementById('vault-modal').classList.remove('active');
+}
+
+function addToVault() {
+  const input = document.getElementById('vault-name-input');
   const name = input.value.trim();
   if (!name) return;
-  const color = AVATAR_COLORS[players.length % AVATAR_COLORS.length];
-  players.push({ name, emoji: null, color });
-  savePlayers();
-  renderPlayers();
-  syncPlayersFilter();
+  if (vault.some(p => p.name.toLowerCase() === name.toLowerCase())) {
+    input.classList.add('input-error');
+    input.select();
+    setTimeout(() => input.classList.remove('input-error'), 1200);
+    return;
+  }
+  const color = AVATAR_COLORS[vault.length % AVATAR_COLORS.length];
+  vault.push({ id: Date.now().toString(), name, emoji: null, color });
+  saveVault();
+  renderVaultList();
+  renderRollCall();
   input.value = '';
   input.focus();
 }
 
-function removePlayer(index) {
-  players.splice(index, 1);
-  savePlayers();
-  renderPlayers();
+function removeFromVault(id) {
+  vault = vault.filter(p => p.id !== id);
+  rollCall.delete(id);
+  saveVault();
+  renderVaultList();
+  renderRollCall();
   syncPlayersFilter();
 }
 
-function savePlayers() {
-  localStorage.setItem('sz-players', JSON.stringify(players));
+function saveVault() {
+  localStorage.setItem('sz-vault', JSON.stringify(vault));
+}
+
+function renderVaultList() {
+  const container = document.getElementById('vault-list');
+  if (!container) return;
+  if (vault.length === 0) {
+    container.innerHTML = '<p class="no-players-msg">No players yet — add your game group above.</p>';
+    return;
+  }
+  container.innerHTML = vault.map(p => `
+    <div class="player-chip">
+      ${avatarHtml(p, true)}
+      <span class="player-name">${p.name}</span>
+      <button class="player-remove" onclick="removeFromVault('${p.id}')">×</button>
+    </div>
+  `).join('');
+}
+
+// ── Roll Call ──────────────────────────────────────────────────────────────
+function toggleRollCall(id) {
+  if (rollCall.has(id)) {
+    rollCall.delete(id);
+  } else {
+    rollCall.add(id);
+  }
+  renderRollCall();
+  syncPlayersFilter();
+}
+
+function renderRollCall() {
+  const container = document.getElementById('roll-call-chips');
+  if (!container) return;
+  if (vault.length === 0) {
+    container.innerHTML = '<p class="no-players-msg">Open the Player Vault to register your game group.</p>';
+    return;
+  }
+  container.innerHTML = vault.map(p => {
+    const active = rollCall.has(p.id);
+    return `
+      <div class="roll-call-chip ${active ? 'active' : ''}" onclick="toggleRollCall('${p.id}')">
+        ${avatarHtml(p)}
+        <span class="player-name">${p.name}</span>
+        ${active ? '<span class="check">✓</span>' : ''}
+      </div>
+    `;
+  }).join('');
 }
 
 function syncPlayersFilter() {
-  document.getElementById('players').value = players.length > 0 ? players.length : '';
+  document.getElementById('players').value = rollCall.size > 0 ? rollCall.size : '';
 }
 
-function avatarHtml(player, playerIndex) {
+// ── Avatars ────────────────────────────────────────────────────────────────
+function avatarHtml(player, clickable = false) {
   const isEmoji = !!player.emoji;
   const content = isEmoji
     ? player.emoji
     : player.name.split(' ').map(w => w[0]).join('').slice(0, 2).toUpperCase();
   const style = isEmoji ? '' : `style="background:${player.color}"`;
-  const clickHandler = playerIndex !== null ? `onclick="openEmojiPicker(${playerIndex})"` : '';
+  const clickHandler = clickable ? `onclick="openEmojiPicker('${player.id}')"` : '';
   return `<div class="avatar ${isEmoji ? 'avatar-emoji' : 'avatar-initials'}" ${style} ${clickHandler}>${content}</div>`;
 }
 
-function renderPlayers() {
-  const container = document.getElementById('player-chips');
-  if (!container) return;
-  container.innerHTML = players.map((p, i) => `
-    <div class="player-chip">
-      ${avatarHtml(p, i)}
-      <span class="player-name">${p.name}</span>
-      <button class="player-remove" onclick="removePlayer(${i})">×</button>
-    </div>
-  `).join('');
-}
-
 // ── Emoji Picker ───────────────────────────────────────────────────────────
-function openEmojiPicker(playerIndex) {
-  emojiPickerTarget = playerIndex;
+function openEmojiPicker(playerId) {
+  emojiPickerTarget = playerId;
   const grid = document.getElementById('emoji-grid');
   grid.innerHTML = AVATAR_EMOJIS.map(e =>
     `<button class="emoji-option" onclick="selectPlayerEmoji('${e}')">${e}</button>`
@@ -87,18 +143,26 @@ function openEmojiPicker(playerIndex) {
 
 function selectPlayerEmoji(emoji) {
   if (emojiPickerTarget !== null) {
-    players[emojiPickerTarget].emoji = emoji;
-    savePlayers();
-    renderPlayers();
+    const player = vault.find(p => p.id === emojiPickerTarget);
+    if (player) {
+      player.emoji = emoji;
+      saveVault();
+      renderVaultList();
+      renderRollCall();
+    }
   }
   closeEmojiPicker();
 }
 
 function clearPlayerEmoji() {
   if (emojiPickerTarget !== null) {
-    players[emojiPickerTarget].emoji = null;
-    savePlayers();
-    renderPlayers();
+    const player = vault.find(p => p.id === emojiPickerTarget);
+    if (player) {
+      player.emoji = null;
+      saveVault();
+      renderVaultList();
+      renderRollCall();
+    }
   }
   closeEmojiPicker();
 }
@@ -277,7 +341,7 @@ async function askWhy(btn, game, filters) {
 // ── Session Modal ──────────────────────────────────────────────────────────
 function openSession(index) {
   sessionGame = renderedGames[index];
-  sessionPlayers = players.map(p => ({ ...p }));
+  sessionPlayers = vault.filter(p => rollCall.has(p.id));
   document.getElementById('session-game-title').textContent = sessionGame.name;
   renderSessionPlayers();
   resetTimer();
@@ -297,12 +361,12 @@ function removeSessionPlayer(index) {
 function renderSessionPlayers() {
   const container = document.getElementById('session-player-list');
   if (sessionPlayers.length === 0) {
-    container.innerHTML = '<p class="no-players-msg">No players registered — add players in the "Who\'s Playing?" panel above.</p>';
+    container.innerHTML = '<p class="no-players-msg">No players on the Roll Call — tap players above to add them.</p>';
     return;
   }
   container.innerHTML = sessionPlayers.map((p, i) => `
     <div class="player-chip">
-      ${avatarHtml(p, null)}
+      ${avatarHtml(p)}
       <span class="player-name">${p.name}</span>
       <button class="player-remove" onclick="removeSessionPlayer(${i})">×</button>
     </div>

--- a/index.html
+++ b/index.html
@@ -13,14 +13,12 @@
       <p class="subtitle">So many games, so little night.</p>
     </header>
 
-    <section class="player-registration">
-      <h2 class="section-label">Who's Playing Tonight?</h2>
-      <div class="player-input-row">
-        <input type="text" id="player-name-input" placeholder="Add a player..."
-               onkeydown="if(event.key==='Enter') addPlayerFromInput()" />
-        <button id="add-player-btn" onclick="addPlayerFromInput()">Add</button>
+    <section class="roll-call">
+      <div class="roll-call-header">
+        <h2 class="section-label">Roll Call</h2>
+        <button class="vault-btn" onclick="openVault()">Player Vault</button>
       </div>
-      <div id="player-chips" class="player-chips"></div>
+      <div id="roll-call-chips" class="roll-call-chips"></div>
     </section>
 
     <section class="filters">
@@ -130,6 +128,24 @@
     <section id="no-results" class="no-results hidden">
       <p>No games matched your filters. Try loosening the constraints!</p>
     </section>
+  </div>
+
+  <!-- Player Vault Modal -->
+  <div id="vault-modal" class="modal-overlay">
+    <div class="modal-panel">
+      <div class="modal-header">
+        <div class="session-title">Player Vault</div>
+        <button class="modal-close" onclick="closeVault()">×</button>
+      </div>
+      <div class="modal-section">
+        <div class="player-input-row">
+          <input type="text" id="vault-name-input" placeholder="Add a player..."
+                 onkeydown="if(event.key==='Enter') addToVault()" />
+          <button id="add-vault-btn" onclick="addToVault()">Add</button>
+        </div>
+        <div id="vault-list" class="vault-list"></div>
+      </div>
+    </div>
   </div>
 
   <!-- Session Modal -->

--- a/style.css
+++ b/style.css
@@ -275,13 +275,20 @@ button:hover {
   border: 1px solid #0f3460;
 }
 
-/* ── Player Registration ─────────────────────────────────────────────────── */
-.player-registration {
+/* ── Roll Call ───────────────────────────────────────────────────────────── */
+.roll-call {
   background: #16213e;
   border-radius: 12px;
   padding: 1.5rem;
   margin-bottom: 1.5rem;
   border: 1px solid #0f3460;
+}
+
+.roll-call-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.8rem;
 }
 
 .section-label {
@@ -290,13 +297,76 @@ button:hover {
   color: #9a9ab0;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  margin-bottom: 0.8rem;
 }
 
+.vault-btn {
+  flex: unset;
+  padding: 0.35rem 0.9rem;
+  background: transparent;
+  border: 1px solid #f5c842;
+  border-radius: 6px;
+  color: #f5c842;
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.vault-btn:hover {
+  background: rgba(245, 200, 66, 0.1);
+  opacity: 1;
+}
+
+.roll-call-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.roll-call-chip {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: #0f3460;
+  border: 1px solid #1a4a80;
+  border-radius: 20px;
+  padding: 0.3rem 0.7rem 0.3rem 0.3rem;
+  cursor: pointer;
+  opacity: 0.45;
+  transition: opacity 0.15s, border-color 0.15s;
+  user-select: none;
+}
+
+.roll-call-chip:hover {
+  opacity: 0.75;
+}
+
+.roll-call-chip.active {
+  opacity: 1;
+  border-color: #f5c842;
+}
+
+.roll-call-chip.active:hover {
+  opacity: 0.85;
+}
+
+.check {
+  font-size: 0.75rem;
+  color: #f5c842;
+  font-weight: 700;
+}
+
+/* ── Player Vault Modal list ─────────────────────────────────────────────── */
+.vault-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 0.8rem;
+}
+
+/* ── Player Input Row (shared: vault modal) ──────────────────────────────── */
 .player-input-row {
   display: flex;
   gap: 0.6rem;
-  margin-bottom: 0.8rem;
 }
 
 .player-input-row input[type="text"] {
@@ -314,18 +384,22 @@ button:hover {
   border-color: #f5c842;
 }
 
-#add-player-btn {
+.player-input-row input[type="text"].input-error {
+  border-color: #e05252;
+  animation: shake 0.3s ease;
+}
+
+@keyframes shake {
+  0%, 100% { transform: translateX(0); }
+  25%       { transform: translateX(-6px); }
+  75%       { transform: translateX(6px); }
+}
+
+#add-vault-btn {
   flex: unset;
   padding: 0.6rem 1.2rem;
   background: #f5c842;
   color: #1a1a2e;
-}
-
-.player-chips {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  min-height: 0;
 }
 
 .player-chip {


### PR DESCRIPTION
## Summary
- **Player registration panel** — add players by name, auto-colored initials avatars, emoji picker on click, persisted to localStorage, auto-sets the Players filter to headcount
- **Expandable game cards** — click any card to reveal age, co-op status, played history, and a "Let's Play!" button
- **Session modal** — opens on "Let's Play!", shows game title, participating players (removable per session), and a start/pause/reset timer

## Issues closed
- Closes #2 (player registration)
- Closes #22 (session modal shell)
- Closes #23 (session timer)

## Not in this PR
Remaining session panels (#24–#30: score tracker, seating, wheel of names, dice roller, photos, notes, rules) and Spotify (#1) are separate issues.

## Test plan
- [ ] Add 3+ players — chips appear, Players filter auto-updates
- [ ] Click an avatar — emoji picker opens; select emoji and confirm it saves on refresh
- [ ] Click "Use Initials" in picker — reverts to colored circle
- [ ] Remove a player — filter count decrements
- [ ] Find a game and click the card — it expands with detail row and "Let's Play!" button; clicking another card collapses the first
- [ ] Click "Let's Play!" — session modal opens with game name, player chips, and timer at 0:00:00
- [ ] Start, pause, and reset the timer
- [ ] Remove a player from the session — does not affect the registration panel
- [ ] Close the modal — timer stops

🤖 Generated with [Claude Code](https://claude.com/claude-code)