### PR TITLE
Add Spotify music player to session modal

### DIFF
--- a/app.js
+++ b/app.js
@@ -345,7 +345,35 @@ function openSession(index) {
   document.getElementById('session-game-title').textContent = sessionGame.name;
   renderSessionPlayers();
   resetTimer();
+  loadSpotifyPlaylist(sessionGame);
   document.getElementById('session-modal').classList.add('active');
+}
+
+async function loadSpotifyPlaylist(game) {
+  const container = document.getElementById('spotify-container');
+  container.innerHTML = '<p class="no-players-msg">Finding music…</p>';
+  try {
+    const res = await fetch(
+      `/api/spotify/playlist?game=${encodeURIComponent(game.name)}&type=${encodeURIComponent(game.type)}`
+    );
+    const data = await res.json();
+    if (data.embedUrl) {
+      container.innerHTML = `
+        <iframe
+          src="${data.embedUrl}"
+          width="100%"
+          height="152"
+          frameborder="0"
+          allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
+          loading="lazy">
+        </iframe>
+      `;
+    } else {
+      container.innerHTML = '<p class="no-players-msg">No playlist found for this game.</p>';
+    }
+  } catch {
+    container.innerHTML = '<p class="no-players-msg">Could not load music.</p>';
+  }
 }
 
 function closeSession() {

--- a/index.html
+++ b/index.html
@@ -160,6 +160,12 @@
         <div id="session-player-list" class="session-player-list"></div>
       </div>
       <div class="modal-section">
+        <div class="modal-section-label">Music</div>
+        <div id="spotify-container" class="spotify-container">
+          <p class="no-players-msg">Finding music…</p>
+        </div>
+      </div>
+      <div class="modal-section">
         <div class="modal-section-label">Timer</div>
         <div id="timer-display" class="timer-display">0:00:00</div>
         <div class="timer-controls">

--- a/server.js
+++ b/server.js
@@ -6,6 +6,77 @@ const Anthropic = require("@anthropic-ai/sdk");
 
 const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
 
+// ── Spotify ────────────────────────────────────────────────────────────────
+let spotifyToken = null;
+let spotifyTokenExpiry = 0;
+
+const TYPE_PLAYLIST_QUERIES = {
+  Party:     "fun party game night playlist",
+  Board:     "board game night music instrumental",
+  Card:      "card game night music",
+  Abstract:  "focus instrumental concentration music",
+  Mystery:   "mystery atmospheric suspense music",
+  Narrative: "storytelling ambient cinematic music",
+  Dice:      "tabletop rpg game music",
+};
+
+async function getSpotifyToken() {
+  if (spotifyToken && Date.now() < spotifyTokenExpiry) return spotifyToken;
+  const creds = Buffer.from(
+    `${process.env.SPOTIFY_CLIENT_ID}:${process.env.SPOTIFY_CLIENT_SECRET}`
+  ).toString("base64");
+  const res = await fetch("https://accounts.spotify.com/api/token", {
+    method: "POST",
+    headers: {
+      Authorization: `Basic ${creds}`,
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: "grant_type=client_credentials",
+  });
+  const data = await res.json();
+  spotifyToken = data.access_token;
+  spotifyTokenExpiry = Date.now() + (data.expires_in - 60) * 1000;
+  return spotifyToken;
+}
+
+async function searchPlaylist(token, query) {
+  const res = await fetch(
+    `https://api.spotify.com/v1/search?q=${encodeURIComponent(query)}&type=playlist&limit=5`,
+    { headers: { Authorization: `Bearer ${token}` } }
+  );
+  const data = await res.json();
+  return data.playlists?.items?.filter(Boolean) ?? [];
+}
+
+async function handleSpotifyPlaylist(req, res) {
+  const url = new URL(req.url, "http://localhost");
+  const game = url.searchParams.get("game") || "";
+  const type = url.searchParams.get("type") || "";
+  try {
+    const token = await getSpotifyToken();
+    let playlists = await searchPlaylist(token, `${game} board game music`);
+    if (playlists.length === 0) {
+      const fallback = TYPE_PLAYLIST_QUERIES[type] || "board game night music";
+      playlists = await searchPlaylist(token, fallback);
+    }
+    if (playlists.length === 0) {
+      res.writeHead(404, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "No playlist found" }));
+      return;
+    }
+    const playlist = playlists[0];
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({
+      embedUrl: `https://open.spotify.com/embed/playlist/${playlist.id}?utm_source=generator&theme=0`,
+      name: playlist.name,
+    }));
+  } catch (err) {
+    console.error(err);
+    res.writeHead(500, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: err.message }));
+  }
+}
+
 const MIME_TYPES = {
   ".html": "text/html",
   ".css": "text/css",
@@ -82,6 +153,8 @@ const server = http.createServer((req, res) => {
   res.setHeader("Access-Control-Allow-Origin", "*");
   if (req.method === "POST" && req.url === "/api/why") {
     handleWhy(req, res);
+  } else if (req.method === "GET" && req.url.startsWith("/api/spotify/playlist")) {
+    handleSpotifyPlaylist(req, res);
   } else {
     serveStatic(req, res);
   }

--- a/style.css
+++ b/style.css
@@ -628,6 +628,12 @@ button:hover {
   border: 1px solid #1a4a80;
 }
 
+/* ── Spotify Player ──────────────────────────────────────────────────────── */
+.spotify-container iframe {
+  border-radius: 10px;
+  display: block;
+}
+
 /* ── Emoji Picker ────────────────────────────────────────────────────────── */
 .emoji-picker {
   background: #16213e;


### PR DESCRIPTION
## Summary
- **Server**: Spotify client credentials token flow — fetched on first request, cached in memory, auto-refreshed before expiry. New `/api/spotify/playlist` endpoint searches by game name (`{game} board game music`), falls back to a game-type-specific query if no results are found.
- **Session modal**: Music panel with an embedded Spotify iframe (dark theme, rounded corners). Loads automatically when "Let's Play!" is clicked.

## Type fallbacks
| Game Type | Fallback Query |
|---|---|
| Party | fun party game night playlist |
| Board | board game night music instrumental |
| Card | card game night music |
| Abstract | focus instrumental concentration music |
| Mystery | mystery atmospheric suspense music |
| Narrative | storytelling ambient cinematic music |
| Dice | tabletop rpg game music |

## Closes
- Closes #1

## Test plan
- [ ] Restart server to load Spotify env vars
- [ ] Open Player Vault, add players, do Roll Call
- [ ] Find a game (e.g. Catan) → click card → "Let's Play!"
- [ ] Music panel appears with "Finding music…" then loads a Spotify embed
- [ ] Try a less common game — confirm fallback playlist loads
- [ ] Confirm iframe is dark-themed and has rounded corners

🤖 Generated with [Claude Code](https://claude.com/claude-code)