### PR TITLE
Per-player feedback form with chip selector

### DIFF
--- a/app.js
+++ b/app.js
@@ -24,8 +24,8 @@ let sessionOutcome = null; // 'win' | 'loss' (winlose mode only)
 let currentSessionId = null;
 
 // Feedback
-let feedbackRating = 0;
-let feedbackPlayAgain = null;
+let feedbackByPlayer = {};     // { [playerId]: { rating, playAgain, notes } }
+let activeFeedbackPlayer = null;
 
 // ── Init ───────────────────────────────────────────────────────────────────
 fetch("games.json")
@@ -531,8 +531,8 @@ function endGame() {
     return;
   }
   stopTimer();
-  feedbackRating = 0;
-  feedbackPlayAgain = null;
+  feedbackByPlayer = {};
+  activeFeedbackPlayer = null;
   renderFeedbackView();
   showFeedbackView();
 }
@@ -670,9 +670,13 @@ function finalizeSession() {
     ...(scoreMode === 'winlose' ? { outcome: sessionOutcome } : { lowScoreWins: lowWins }),
     players,
     timerSeconds,
-    rating: feedbackRating || null,
-    playAgain: feedbackPlayAgain,
-    notes: document.getElementById('session-notes')?.value.trim() || null,
+    feedback: Object.fromEntries(
+      Object.entries(feedbackByPlayer).map(([id, fb]) => [id, {
+        rating: fb.rating || null,
+        playAgain: fb.playAgain,
+        notes: fb.notes.trim() || null,
+      }])
+    ),
   };
 
   saveResult(result);
@@ -715,34 +719,102 @@ function renderFeedbackView() {
     <div class="summary-row"><span>Result</span><span>${resultLine}</span></div>
   `;
 
-  document.getElementById('session-notes').value = '';
-  renderStars(0);
-  renderPlayAgain(null);
+  // Initialize per-player feedback state
+  sessionPlayers.forEach(p => {
+    if (!feedbackByPlayer[p.id]) {
+      feedbackByPlayer[p.id] = { rating: 0, playAgain: null, notes: '' };
+    }
+  });
+  activeFeedbackPlayer = sessionPlayers[0]?.id ?? null;
+
+  renderFeedbackPlayerChips();
+  renderPlayerFeedbackForm();
 }
 
-function renderStars(rating) {
-  const container = document.getElementById('star-rating');
-  if (!container) return;
-  container.innerHTML = [1, 2, 3, 4, 5].map(i =>
-    `<button class="star-btn ${i <= rating ? 'star-on' : ''}" onclick="setRating(${i})">★</button>`
+function renderFeedbackPlayerChips() {
+  const chips = document.getElementById('feedback-player-chips');
+  const progress = document.getElementById('feedback-progress');
+  if (!chips || !progress) return;
+
+  const doneCount = sessionPlayers.filter(p => {
+    const fb = feedbackByPlayer[p.id];
+    return fb && (fb.rating > 0 || fb.playAgain !== null);
+  }).length;
+  progress.textContent = `${doneCount} of ${sessionPlayers.length} done`;
+
+  chips.innerHTML = sessionPlayers.map(p => {
+    const fb = feedbackByPlayer[p.id];
+    const done = fb && (fb.rating > 0 || fb.playAgain !== null);
+    const active = p.id === activeFeedbackPlayer;
+    return `
+      <div class="feedback-chip ${active ? 'active' : ''} ${done ? 'done' : ''}"
+           onclick="selectFeedbackPlayer('${p.id}')">
+        ${avatarHtml(p)}
+        <span class="player-name">${p.name}</span>
+        ${done ? '<span class="feedback-chip-check">✓</span>' : ''}
+      </div>
+    `;
+  }).join('');
+}
+
+function renderPlayerFeedbackForm() {
+  const player = sessionPlayers.find(p => p.id === activeFeedbackPlayer);
+  const container = document.getElementById('feedback-player-form');
+  if (!player || !container) return;
+
+  const fb = feedbackByPlayer[player.id];
+  const stars = [1, 2, 3, 4, 5].map(i =>
+    `<button class="star-btn ${i <= fb.rating ? 'star-on' : ''}" onclick="setRating(${i})">★</button>`
   ).join('');
+
+  container.innerHTML = `
+    <div class="feedback-active-player">
+      ${avatarHtml(player)}
+      <span class="feedback-active-name">${player.name}</span>
+    </div>
+    <div class="feedback-field">
+      <div class="modal-section-label">Rating</div>
+      <div class="star-rating">${stars}</div>
+    </div>
+    <div class="feedback-field">
+      <div class="modal-section-label">Play Again?</div>
+      <div class="play-again-btns">
+        <button class="play-again-btn ${fb.playAgain === 'yes'   ? 'play-again-active' : ''}" onclick="setPlayAgain('yes')">👍 Yes</button>
+        <button class="play-again-btn ${fb.playAgain === 'maybe' ? 'play-again-active' : ''}" onclick="setPlayAgain('maybe')">🤔 Maybe</button>
+        <button class="play-again-btn ${fb.playAgain === 'no'    ? 'play-again-active' : ''}" onclick="setPlayAgain('no')">👎 No</button>
+      </div>
+    </div>
+    <div class="feedback-field">
+      <div class="modal-section-label">Notes</div>
+      <textarea class="session-notes" oninput="saveFeedbackNotes(this.value)"
+                placeholder="Highlights, house rules, memorable moments…">${fb.notes}</textarea>
+    </div>
+  `;
+}
+
+function selectFeedbackPlayer(id) {
+  activeFeedbackPlayer = id;
+  renderFeedbackPlayerChips();
+  renderPlayerFeedbackForm();
 }
 
 function setRating(n) {
-  feedbackRating = n;
-  renderStars(n);
-}
-
-function renderPlayAgain(val) {
-  ['yes', 'maybe', 'no'].forEach(v => {
-    const btn = document.getElementById(`pa-${v}`);
-    if (btn) btn.classList.toggle('play-again-active', val === v);
-  });
+  if (!activeFeedbackPlayer) return;
+  feedbackByPlayer[activeFeedbackPlayer].rating = n;
+  renderPlayerFeedbackForm();
+  renderFeedbackPlayerChips();
 }
 
 function setPlayAgain(val) {
-  feedbackPlayAgain = val;
-  renderPlayAgain(val);
+  if (!activeFeedbackPlayer) return;
+  feedbackByPlayer[activeFeedbackPlayer].playAgain = val;
+  renderPlayerFeedbackForm();
+  renderFeedbackPlayerChips();
+}
+
+function saveFeedbackNotes(val) {
+  if (!activeFeedbackPlayer) return;
+  feedbackByPlayer[activeFeedbackPlayer].notes = val;
 }
 
 

--- a/index.html
+++ b/index.html
@@ -193,21 +193,13 @@
                 <div id="feedback-summary" class="feedback-summary"></div>
               </div>
               <div class="feedback-section">
-                <div class="modal-section-label">Rate This Session</div>
-                <div id="star-rating" class="star-rating"></div>
-              </div>
-              <div class="feedback-section">
-                <div class="modal-section-label">Play Again?</div>
-                <div class="play-again-btns">
-                  <button class="play-again-btn" id="pa-yes"   onclick="setPlayAgain('yes')">👍 Yes</button>
-                  <button class="play-again-btn" id="pa-maybe" onclick="setPlayAgain('maybe')">🤔 Maybe</button>
-                  <button class="play-again-btn" id="pa-no"    onclick="setPlayAgain('no')">👎 No</button>
+                <div class="feedback-player-header">
+                  <div class="modal-section-label">Player Feedback</div>
+                  <div class="feedback-progress" id="feedback-progress"></div>
                 </div>
+                <div id="feedback-player-chips" class="feedback-player-chips"></div>
               </div>
-              <div class="feedback-section">
-                <div class="modal-section-label">Notes</div>
-                <textarea id="session-notes" class="session-notes" placeholder="Highlights, house rules, memorable moments…"></textarea>
-              </div>
+              <div id="feedback-player-form" class="feedback-player-form"></div>
               <div class="feedback-actions">
                 <button class="back-btn" onclick="backToSession()">← Back</button>
                 <div class="feedback-finalize">

--- a/style.css
+++ b/style.css
@@ -1087,7 +1087,95 @@ button:hover {
 }
 
 .feedback-section {
-  margin-bottom: 1.2rem;
+  margin-bottom: 1rem;
+}
+
+.feedback-player-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.6rem;
+}
+
+.feedback-player-header .modal-section-label {
+  margin-bottom: 0;
+}
+
+.feedback-progress {
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: #6a7a90;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.feedback-player-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.feedback-chip {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: #0f3460;
+  border: 1px solid #1a4a80;
+  border-radius: 20px;
+  padding: 0.25rem 0.6rem 0.25rem 0.25rem;
+  cursor: pointer;
+  opacity: 0.5;
+  transition: opacity 0.15s, border-color 0.15s;
+  user-select: none;
+}
+
+.feedback-chip:hover {
+  opacity: 0.75;
+}
+
+.feedback-chip.active {
+  opacity: 1;
+  border-color: #f5c842;
+}
+
+.feedback-chip.done {
+  opacity: 0.75;
+  border-color: #5dd67a;
+}
+
+.feedback-chip.active.done {
+  opacity: 1;
+  border-color: #5dd67a;
+}
+
+.feedback-chip-check {
+  font-size: 0.7rem;
+  color: #5dd67a;
+  font-weight: 700;
+}
+
+.feedback-active-player {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 0;
+  margin-bottom: 0.6rem;
+  border-bottom: 1px solid #0f3460;
+}
+
+.feedback-active-name {
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: #e0e0e0;
+}
+
+.feedback-player-form {
+  flex: 1;
+  min-height: 0;
+}
+
+.feedback-field {
+  margin-bottom: 0.9rem;
 }
 
 .feedback-summary {


### PR DESCRIPTION
## Summary

- Replaces the single shared feedback form with a per-player system
- Each player gets their own rating (1–5 stars), Play Again preference, and notes — stored under their vault ID
- Player chip selector row matches the Roll Call aesthetic; chips turn green with a ✓ when a player is done
- Progress indicator ("2 of 4 done") updates live
- Feedback saved as a per-player map in the session result, keyed by vault player ID — ready for player stats (#4) and history (#3) later

## Test plan

- [ ] End a game → feedback form slides in with chip row and first player active
- [ ] Fill in stars and Play Again for player 1 → chip turns green with ✓, progress updates
- [ ] Switch to another player chip → form updates to that player's (empty) state
- [ ] Switch back to player 1 → their data is preserved
- [ ] Notes saved per player, not shared
- [ ] Finalize → result saved with `feedback` map keyed by player ID (check localStorage `sz-history`)

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)