### PR TITLE
Play History modal (#3)

### DIFF
--- a/app.js
+++ b/app.js
@@ -643,6 +643,87 @@ function renderGamesInProgress() {
   }).join('');
 }
 
+// ── Play History ───────────────────────────────────────────────────────────
+function openHistory() {
+  renderHistory();
+  document.getElementById('history-modal').classList.add('active');
+}
+
+function closeHistory() {
+  document.getElementById('history-modal').classList.remove('active');
+}
+
+function renderHistory() {
+  const history = JSON.parse(localStorage.getItem('sz-history') || '[]');
+  const container = document.getElementById('history-list');
+  if (!container) return;
+
+  if (history.length === 0) {
+    container.innerHTML = '<p class="no-players-msg">No sessions recorded yet.</p>';
+    return;
+  }
+
+  container.innerHTML = history.map(entry => {
+    const date = new Date(entry.date + 'T12:00:00').toLocaleDateString('en-US', {
+      month: 'short', day: 'numeric', year: '2-digit',
+    });
+
+    const h = Math.floor(entry.timerSeconds / 3600);
+    const m = Math.floor((entry.timerSeconds % 3600) / 60);
+    const duration = h > 0 ? `${h}h ${m}m` : `${m}m`;
+
+    let resultHtml = '';
+    if (entry.mode === 'winlose') {
+      resultHtml = entry.outcome === 'win' ? '🎉 Victory' : '💀 Defeat';
+    } else {
+      const sorted = [...entry.players].sort((a, b) =>
+        entry.lowScoreWins ? a.score - b.score : b.score - a.score
+      );
+      resultHtml = sorted.map((p, i) =>
+        `<span class="${i === 0 ? 'history-winner' : ''}">${p.name}: ${p.score}</span>`
+      ).join('<span class="history-sep"> · </span>');
+    }
+
+    const feedbackValues = entry.feedback ? Object.values(entry.feedback) : [];
+    const ratings = feedbackValues.map(f => f.rating).filter(Boolean);
+    const avgRating = ratings.length
+      ? Math.round(ratings.reduce((a, b) => a + b, 0) / ratings.length)
+      : 0;
+    const ratingHtml = avgRating
+      ? `<span class="history-stars">${'★'.repeat(avgRating)}${'☆'.repeat(5 - avgRating)}</span>`
+      : '';
+
+    const paCounts = { yes: 0, maybe: 0, no: 0 };
+    feedbackValues.forEach(f => { if (f.playAgain) paCounts[f.playAgain]++; });
+    const paHtml = [
+      paCounts.yes   ? `${paCounts.yes} 👍`   : '',
+      paCounts.maybe ? `${paCounts.maybe} 🤔` : '',
+      paCounts.no    ? `${paCounts.no} 👎`    : '',
+    ].filter(Boolean).join(' · ');
+
+    const playerAvatars = entry.players.map(p => {
+      const vp = vault.find(v => v.id === p.id);
+      return vp ? avatarHtml(vp) : `<div class="avatar avatar-initials" style="background:#6a7a90">${p.name[0].toUpperCase()}</div>`;
+    }).join('');
+
+    return `
+      <div class="history-card">
+        <div class="history-card-top">
+          <span class="history-game">${entry.game}</span>
+          <span class="history-date">${date}</span>
+        </div>
+        <div class="history-players">${playerAvatars}</div>
+        <div class="history-result">${resultHtml}</div>
+        <div class="history-meta">
+          <span>⏱ ${duration}</span>
+          ${ratingHtml}
+          ${paHtml ? `<span>${paHtml}</span>` : ''}
+        </div>
+      </div>
+    `;
+  }).join('');
+}
+
 function finalizeSession() {
   const lowWins = document.getElementById('low-score-wins')?.checked ?? false;
   let players;

--- a/index.html
+++ b/index.html
@@ -16,7 +16,10 @@
     <section class="roll-call">
       <div class="roll-call-header">
         <h2 class="section-label">Roll Call</h2>
-        <button class="vault-btn" onclick="openVault()">Player Vault</button>
+        <div class="roll-call-actions">
+          <button class="vault-btn" onclick="openHistory()">History</button>
+          <button class="vault-btn" onclick="openVault()">Player Vault</button>
+        </div>
       </div>
       <div id="roll-call-chips" class="roll-call-chips"></div>
     </section>
@@ -236,6 +239,19 @@
       <div class="emoji-picker-label">Choose your avatar</div>
       <div id="emoji-grid" class="emoji-grid"></div>
       <button class="emoji-clear-btn" onclick="clearPlayerEmoji()">Use Initials</button>
+    </div>
+  </div>
+
+  <!-- History Modal -->
+  <div id="history-modal" class="modal-overlay" onclick="closeHistory()">
+    <div class="modal-panel history-panel" onclick="event.stopPropagation()">
+      <div class="modal-header">
+        <div class="session-title">Play History</div>
+        <button class="modal-close" onclick="closeHistory()">×</button>
+      </div>
+      <div class="history-body">
+        <div id="history-list" class="history-list"></div>
+      </div>
     </div>
   </div>
 

--- a/style.css
+++ b/style.css
@@ -1395,3 +1395,90 @@ button:hover {
   padding: 0.3rem 0.8rem;
   cursor: pointer;
 }
+
+/* ── Roll Call header actions ────────────────────────────────────────────── */
+.roll-call-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+/* ── Play History Modal ──────────────────────────────────────────────────── */
+.history-panel {
+  max-width: 560px;
+}
+
+.history-body {
+  overflow-y: auto;
+  flex: 1;
+  padding: 1rem 1.2rem;
+}
+
+.history-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+}
+
+.history-card {
+  background: #0f3460;
+  border: 1px solid #1a4a80;
+  border-radius: 10px;
+  padding: 0.75rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.history-card-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.history-game {
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: #e0e0e0;
+}
+
+.history-date {
+  font-size: 0.75rem;
+  color: #6a7a90;
+  white-space: nowrap;
+}
+
+.history-players {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.history-result {
+  font-size: 0.82rem;
+  color: #9a9ab0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.1rem;
+}
+
+.history-winner {
+  color: #f5c842;
+  font-weight: 700;
+}
+
+.history-sep {
+  color: #4a5a70;
+}
+
+.history-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  font-size: 0.78rem;
+  color: #6a7a90;
+}
+
+.history-stars {
+  color: #f5c842;
+  letter-spacing: 0.02em;
+}


### PR DESCRIPTION
## Summary

- Adds a **History** button to the Roll Call header (next to Player Vault)
- Opens a scrollable modal of past sessions, newest first
- Each card shows: game name, date, player avatars, result (winner in gold, Victory/Defeat for co-op), duration, average star rating, and Play Again aggregate from per-player feedback

## Test plan

- [ ] Finalize a session → open History → card appears with correct game, date, and players
- [ ] Points mode: winner's name/score shown in gold, others in grey
- [ ] Win/loss mode: 🎉 Victory or 💀 Defeat shown
- [ ] Star rating shows average across all players who rated
- [ ] Play Again shows per-vote counts (3 👍 · 1 🤔)
- [ ] Click outside modal or × closes it
- [ ] Empty state shows "No sessions recorded yet"

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)