### PR TITLE
Player Stats modal (#4)

### DIFF
--- a/app.js
+++ b/app.js
@@ -758,6 +758,110 @@ function renderHistory() {
   }).join('');
 }
 
+// ── Player Stats ───────────────────────────────────────────────────────────
+function openStats() {
+  renderStats();
+  document.getElementById('stats-modal').classList.add('active');
+}
+
+function closeStats() {
+  document.getElementById('stats-modal').classList.remove('active');
+}
+
+function computePlayerStats(playerId) {
+  const history = JSON.parse(localStorage.getItem('sz-history') || '[]');
+  const sessions = history.filter(e => e.players.some(p => p.id === playerId));
+  const gamesPlayed = sessions.length;
+
+  const wins = sessions.filter(e => {
+    if (e.mode === 'winlose') return e.outcome === 'win';
+    return e.players.find(p => p.id === playerId)?.winner === true;
+  }).length;
+
+  const winRate = gamesPlayed > 0 ? Math.round((wins / gamesPlayed) * 100) : null;
+
+  const gameCounts = {};
+  sessions.forEach(e => { gameCounts[e.game] = (gameCounts[e.game] || 0) + 1; });
+  const favoriteEntry = Object.entries(gameCounts).sort((a, b) => b[1] - a[1])[0];
+
+  const ratings = sessions.map(e => e.feedback?.[playerId]?.rating).filter(Boolean);
+  const avgRating = ratings.length
+    ? Math.round(ratings.reduce((a, b) => a + b, 0) / ratings.length)
+    : 0;
+
+  const paCounts = { yes: 0, maybe: 0, no: 0 };
+  sessions.forEach(e => {
+    const pa = e.feedback?.[playerId]?.playAgain;
+    if (pa) paCounts[pa]++;
+  });
+
+  return { gamesPlayed, wins, winRate, favoriteEntry, avgRating, paCounts };
+}
+
+function renderStats() {
+  const container = document.getElementById('stats-list');
+  if (!container) return;
+
+  if (vault.length === 0) {
+    container.innerHTML = '<p class="no-players-msg">No players in the vault yet.</p>';
+    return;
+  }
+
+  container.innerHTML = vault.map(player => {
+    const s = computePlayerStats(player.id);
+
+    if (s.gamesPlayed === 0) {
+      return `
+        <div class="stats-card">
+          <div class="stats-card-header">
+            ${avatarHtml(player)}
+            <span class="stats-player-name">${player.name}</span>
+          </div>
+          <p class="no-players-msg">No sessions recorded yet.</p>
+        </div>
+      `;
+    }
+
+    const winRateHtml = s.winRate !== null
+      ? `<div class="stats-row"><span>Win Rate</span><span>${s.winRate}% (${s.wins} of ${s.gamesPlayed})</span></div>`
+      : '';
+
+    const favoriteHtml = s.favoriteEntry
+      ? `<div class="stats-row"><span>Favorite Game</span><span>${s.favoriteEntry[0]} <span class="stats-muted">(${s.favoriteEntry[1]}×)</span></span></div>`
+      : '';
+
+    const ratingHtml = s.avgRating
+      ? `<div class="stats-row"><span>Avg Rating Given</span><span class="stats-stars">${'★'.repeat(s.avgRating)}${'☆'.repeat(5 - s.avgRating)}</span></div>`
+      : '';
+
+    const paTotal = s.paCounts.yes + s.paCounts.maybe + s.paCounts.no;
+    const paHtml = paTotal > 0
+      ? `<div class="stats-row"><span>Play Again</span><span>${
+          [s.paCounts.yes   ? `${s.paCounts.yes} 👍`   : '',
+           s.paCounts.maybe ? `${s.paCounts.maybe} 🤔` : '',
+           s.paCounts.no    ? `${s.paCounts.no} 👎`    : '']
+          .filter(Boolean).join(' · ')
+        }</span></div>`
+      : '';
+
+    return `
+      <div class="stats-card">
+        <div class="stats-card-header">
+          ${avatarHtml(player)}
+          <span class="stats-player-name">${player.name}</span>
+          <span class="stats-games-played">${s.gamesPlayed} session${s.gamesPlayed !== 1 ? 's' : ''}</span>
+        </div>
+        <div class="stats-rows">
+          ${winRateHtml}
+          ${favoriteHtml}
+          ${ratingHtml}
+          ${paHtml}
+        </div>
+      </div>
+    `;
+  }).join('');
+}
+
 function finalizeSession() {
   const lowWins = document.getElementById('low-score-wins')?.checked ?? false;
   let players;

--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
         <div class="roll-call-actions">
           <button class="vault-btn" onclick="openSettings()">⚙ Settings</button>
           <button class="vault-btn" onclick="openHistory()">History</button>
+          <button class="vault-btn" onclick="openStats()">Stats</button>
           <button class="vault-btn" onclick="openVault()">Player Vault</button>
         </div>
       </div>
@@ -280,6 +281,19 @@
       </div>
       <div class="history-body">
         <div id="history-list" class="history-list"></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Stats Modal -->
+  <div id="stats-modal" class="modal-overlay" onclick="closeStats()">
+    <div class="modal-panel stats-panel" onclick="event.stopPropagation()">
+      <div class="modal-header">
+        <div class="session-title">Player Stats</div>
+        <button class="modal-close" onclick="closeStats()">×</button>
+      </div>
+      <div class="stats-body">
+        <div id="stats-list" class="stats-list"></div>
       </div>
     </div>
   </div>

--- a/style.css
+++ b/style.css
@@ -1583,3 +1583,82 @@ body.hide-why .why-btn {
   color: #e0e0e0;
   opacity: 1;
 }
+
+/* ── Player Stats Modal ──────────────────────────────────────────────────── */
+.stats-panel {
+  max-width: 520px;
+}
+
+.stats-body {
+  overflow-y: auto;
+  flex: 1;
+  padding: 1rem 1.2rem;
+}
+
+.stats-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+}
+
+.stats-card {
+  background: #0f3460;
+  border: 1px solid #1a4a80;
+  border-radius: 10px;
+  padding: 0.75rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.stats-card-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.stats-player-name {
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: #e0e0e0;
+  flex: 1;
+}
+
+.stats-games-played {
+  font-size: 0.75rem;
+  color: #6a7a90;
+  white-space: nowrap;
+}
+
+.stats-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  border-top: 1px solid #1a4a80;
+  padding-top: 0.5rem;
+}
+
+.stats-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  font-size: 0.82rem;
+}
+
+.stats-row span:first-child {
+  color: #6a7a90;
+  flex-shrink: 0;
+}
+
+.stats-row span:last-child {
+  color: #e0e0e0;
+  text-align: right;
+}
+
+.stats-stars {
+  color: #f5c842;
+}
+
+.stats-muted {
+  color: #6a7a90;
+}


### PR DESCRIPTION
## Summary

- **Stats** button added to Roll Call header
- One card per vault player showing: games played, win rate, favorite game (most played + count), average rating given, and Play Again breakdown
- All derived from `sz-history` — no new data collection needed
- Players with no history show a clean empty state

## Test plan

- [ ] Stats button opens modal with a card per vault player
- [ ] Games played count matches finalized sessions
- [ ] Win rate correct for both points mode (winner flag) and win/loss mode (outcome)
- [ ] Favorite game shows most-played title with play count
- [ ] Avg rating reflects per-player feedback stars
- [ ] Play Again counts match feedback selections
- [ ] Player with no sessions shows "No sessions recorded yet"

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)