### PR TITLE
Head-to-Head records in Stats modal (#5)

### DIFF
--- a/app.js
+++ b/app.js
@@ -759,13 +759,26 @@ function renderHistory() {
 }
 
 // ── Player Stats ───────────────────────────────────────────────────────────
+let activeStatsTab = 'players';
+let h2hSelected = { a: null, b: null };
+
 function openStats() {
+  switchStatsTab('players');
   renderStats();
   document.getElementById('stats-modal').classList.add('active');
 }
 
 function closeStats() {
   document.getElementById('stats-modal').classList.remove('active');
+}
+
+function switchStatsTab(tab) {
+  activeStatsTab = tab;
+  document.getElementById('stats-body-players').classList.toggle('hidden', tab !== 'players');
+  document.getElementById('stats-body-h2h').classList.toggle('hidden', tab !== 'h2h');
+  document.getElementById('tab-players').classList.toggle('active', tab === 'players');
+  document.getElementById('tab-h2h').classList.toggle('active', tab === 'h2h');
+  if (tab === 'h2h') renderH2HSelectors();
 }
 
 function computePlayerStats(playerId) {
@@ -860,6 +873,106 @@ function renderStats() {
       </div>
     `;
   }).join('');
+}
+
+function renderH2HSelectors() {
+  ['a', 'b'].forEach(side => {
+    const container = document.getElementById(`h2h-selector-${side}`);
+    if (!container) return;
+    const selectedId = h2hSelected[side];
+    container.innerHTML = vault.map(p => `
+      <div class="h2h-chip ${p.id === selectedId ? 'active' : ''}"
+           onclick="selectH2HPlayer('${side}', '${p.id}')">
+        ${avatarHtml(p)}
+        <span class="player-name">${p.name}</span>
+      </div>
+    `).join('');
+  });
+  renderH2HResult();
+}
+
+function selectH2HPlayer(side, id) {
+  h2hSelected[side] = h2hSelected[side] === id ? null : id;
+  renderH2HSelectors();
+}
+
+function computeHeadToHead(idA, idB) {
+  const history = JSON.parse(localStorage.getItem('sz-history') || '[]');
+  const shared = history.filter(e =>
+    e.players.some(p => p.id === idA) && e.players.some(p => p.id === idB)
+  );
+
+  let winsA = 0, winsB = 0, ties = 0, coop = 0;
+
+  shared.forEach(e => {
+    if (e.mode === 'winlose') {
+      coop++;
+      return;
+    }
+    const pA = e.players.find(p => p.id === idA);
+    const pB = e.players.find(p => p.id === idB);
+    const scoreA = pA?.score ?? 0;
+    const scoreB = pB?.score ?? 0;
+    const lowWins = e.lowScoreWins ?? false;
+
+    if (scoreA === scoreB) {
+      ties++;
+    } else if (lowWins ? scoreA < scoreB : scoreA > scoreB) {
+      winsA++;
+    } else {
+      winsB++;
+    }
+  });
+
+  return { total: shared.length, winsA, winsB, ties, coop };
+}
+
+function renderH2HResult() {
+  const container = document.getElementById('h2h-result');
+  if (!container) return;
+  const { a: idA, b: idB } = h2hSelected;
+
+  if (!idA || !idB) {
+    container.innerHTML = '<p class="no-players-msg">Select two players to see their record.</p>';
+    return;
+  }
+  if (idA === idB) {
+    container.innerHTML = '<p class="no-players-msg">Select two different players.</p>';
+    return;
+  }
+
+  const playerA = vault.find(p => p.id === idA);
+  const playerB = vault.find(p => p.id === idB);
+  const r = computeHeadToHead(idA, idB);
+
+  if (r.total === 0) {
+    container.innerHTML = '<p class="no-players-msg">These players haven\'t played together yet.</p>';
+    return;
+  }
+
+  const competitive = r.total - r.coop;
+
+  container.innerHTML = `
+    <div class="h2h-scoreboard">
+      <div class="h2h-player">
+        ${avatarHtml(playerA)}
+        <span class="h2h-name">${playerA.name}</span>
+        <span class="h2h-score ${r.winsA > r.winsB ? 'h2h-leader' : ''}">${r.winsA}</span>
+      </div>
+      <div class="h2h-divider">–</div>
+      <div class="h2h-player h2h-player-right">
+        <span class="h2h-score ${r.winsB > r.winsA ? 'h2h-leader' : ''}">${r.winsB}</span>
+        <span class="h2h-name">${playerB.name}</span>
+        ${avatarHtml(playerB)}
+      </div>
+    </div>
+    <div class="h2h-meta">
+      <span>${r.total} session${r.total !== 1 ? 's' : ''} together</span>
+      ${competitive > 0 ? `<span>${competitive} competitive</span>` : ''}
+      ${r.ties > 0 ? `<span>${r.ties} tie${r.ties !== 1 ? 's' : ''}</span>` : ''}
+      ${r.coop > 0 ? `<span>${r.coop} co-op</span>` : ''}
+    </div>
+  `;
 }
 
 function finalizeSession() {

--- a/index.html
+++ b/index.html
@@ -292,8 +292,20 @@
         <div class="session-title">Player Stats</div>
         <button class="modal-close" onclick="closeStats()">×</button>
       </div>
-      <div class="stats-body">
+      <div class="stats-tabs">
+        <button class="stats-tab active" id="tab-players" onclick="switchStatsTab('players')">Players</button>
+        <button class="stats-tab" id="tab-h2h" onclick="switchStatsTab('h2h')">Head-to-Head</button>
+      </div>
+      <div class="stats-body" id="stats-body-players">
         <div id="stats-list" class="stats-list"></div>
+      </div>
+      <div class="stats-body hidden" id="stats-body-h2h">
+        <div class="h2h-selectors">
+          <div class="h2h-selector" id="h2h-selector-a"></div>
+          <div class="h2h-vs">vs.</div>
+          <div class="h2h-selector" id="h2h-selector-b"></div>
+        </div>
+        <div id="h2h-result" class="h2h-result"></div>
       </div>
     </div>
   </div>

--- a/style.css
+++ b/style.css
@@ -1662,3 +1662,133 @@ body.hide-why .why-btn {
 .stats-muted {
   color: #6a7a90;
 }
+
+/* ── Stats Tabs ──────────────────────────────────────────────────────────── */
+.stats-tabs {
+  display: flex;
+  border-bottom: 1px solid #0f3460;
+  flex-shrink: 0;
+}
+
+.stats-tab {
+  flex: 1;
+  padding: 0.55rem;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: #6a7a90;
+  font-size: 0.82rem;
+  font-weight: 600;
+  cursor: pointer;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  transition: color 0.15s;
+  margin-bottom: -1px;
+}
+
+.stats-tab:hover {
+  color: #9a9ab0;
+  opacity: 1;
+}
+
+.stats-tab.active {
+  color: #f5c842;
+  border-bottom-color: #f5c842;
+}
+
+/* ── Head-to-Head ────────────────────────────────────────────────────────── */
+.h2h-selectors {
+  display: flex;
+  gap: 0.5rem;
+  align-items: flex-start;
+  margin-bottom: 1rem;
+}
+
+.h2h-selector {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.h2h-vs {
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: #6a7a90;
+  padding-top: 0.3rem;
+  flex-shrink: 0;
+}
+
+.h2h-chip {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: #0f3460;
+  border: 1px solid #1a4a80;
+  border-radius: 20px;
+  padding: 0.25rem 0.6rem 0.25rem 0.25rem;
+  cursor: pointer;
+  opacity: 0.5;
+  transition: opacity 0.15s, border-color 0.15s;
+  user-select: none;
+}
+
+.h2h-chip:hover { opacity: 0.75; }
+.h2h-chip.active { opacity: 1; border-color: #f5c842; }
+
+.h2h-scoreboard {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 1rem 0;
+  border-top: 1px solid #0f3460;
+}
+
+.h2h-player {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.4rem;
+  flex: 1;
+}
+
+.h2h-player-right {
+  align-items: center;
+}
+
+.h2h-name {
+  font-size: 0.82rem;
+  color: #9a9ab0;
+  text-align: center;
+}
+
+.h2h-score {
+  font-size: 2.5rem;
+  font-weight: 700;
+  color: #4a5a70;
+  line-height: 1;
+}
+
+.h2h-leader {
+  color: #f5c842;
+}
+
+.h2h-divider {
+  font-size: 1.5rem;
+  color: #4a5a70;
+  flex-shrink: 0;
+}
+
+.h2h-meta {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  font-size: 0.75rem;
+  color: #6a7a90;
+  padding-bottom: 0.5rem;
+}
+
+.h2h-result {
+  min-height: 60px;
+}


### PR DESCRIPTION
## Summary

- Adds a **Players / Head-to-Head** tab switcher to the Stats modal
- H2H tab: pick two players from chip selectors to see their competitive record
- Shows wins each, ties, total sessions together, and co-op session count
- Winner determined by score with Low Score Wins flag respected
- Co-op sessions tallied separately (both players share the outcome)

## Test plan

- [ ] Stats modal shows Players and Head-to-Head tabs
- [ ] Selecting two players shows their win/loss record
- [ ] Selecting the same player twice shows an error message
- [ ] Players with no shared sessions show appropriate empty state
- [ ] Leader score displays in gold
- [ ] Ties and co-op counts appear when applicable

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)