### PR TITLE
Per-game Spotify playlist: custom search and save

### DIFF
--- a/app.js
+++ b/app.js
@@ -28,7 +28,8 @@ let feedbackByPlayer = {};     // { [playerId]: { rating, playAgain, notes } }
 let activeFeedbackPlayer = null;
 
 // Spotify
-let currentSpotifyData = null; // { embedUrl, name } — the playlist currently showing
+let currentSpotifyData = null;    // { embedUrl, name } — the playlist currently showing
+let currentSpotifyOptions = [];   // full list returned by last fetch
 
 // Settings
 const SETTINGS_DEFAULTS = { showWhyBtn: true };
@@ -554,11 +555,12 @@ function openSession(index) {
 async function loadSpotifyPlaylist(game) {
   const container = document.getElementById('spotify-container');
   currentSpotifyData = null;
+  currentSpotifyOptions = [];
 
   // Use saved playlist if available
   if (game.spotifyEmbedUrl) {
     currentSpotifyData = { embedUrl: game.spotifyEmbedUrl, name: game.spotifyPlaylistName || '' };
-    renderSpotifyEmbed(container, currentSpotifyData, true);
+    renderSpotifyOptions(container, [currentSpotifyData], 0, true);
     return;
   }
 
@@ -568,9 +570,8 @@ async function loadSpotifyPlaylist(game) {
       `/api/spotify/playlist?game=${encodeURIComponent(game.name)}&type=${encodeURIComponent(game.type)}`
     );
     const data = await res.json();
-    if (data.embedUrl) {
-      currentSpotifyData = data;
-      renderSpotifyEmbed(container, data, false);
+    if (data.playlists?.length) {
+      renderSpotifyOptions(container, data.playlists, 0, false);
     } else {
       renderSpotifyNoResult(container);
     }
@@ -579,19 +580,29 @@ async function loadSpotifyPlaylist(game) {
   }
 }
 
-function renderSpotifyEmbed(container, data, isSaved) {
-  const safeName = data.name.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+function renderSpotifyOptions(container, options, selectedIdx, isSaved) {
+  currentSpotifyOptions = options;
+  currentSpotifyData = options[selectedIdx];
+
+  const optionsHtml = options.length > 1
+    ? `<div class="spotify-options">${options.map((opt, i) => {
+        const safe = opt.name.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+        return `<button class="spotify-option-btn${i === selectedIdx ? ' active' : ''}"
+          onclick="selectSpotifyOption(${i})" title="${safe}">${safe}</button>`;
+      }).join('')}</div>`
+    : '';
+
   container.innerHTML = `
-    <iframe
-      src="${data.embedUrl}"
+    <iframe id="spotify-iframe"
+      src="${options[selectedIdx].embedUrl}"
       width="100%"
       height="152"
       frameborder="0"
       allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
       loading="lazy">
     </iframe>
+    ${optionsHtml}
     <div class="spotify-meta">
-      <span class="spotify-playlist-name" title="${safeName}">${safeName}</span>
       <div class="spotify-actions">
         <button class="spotify-change-btn" onclick="showSpotifySearch()">Change</button>
         <button class="spotify-save-btn${isSaved ? ' saved' : ''}" onclick="saveSpotifyPlaylist()">
@@ -605,6 +616,21 @@ function renderSpotifyEmbed(container, data, isSaved) {
       <button onclick="searchSpotifyQuery()">Search</button>
     </div>
   `;
+}
+
+function selectSpotifyOption(idx) {
+  currentSpotifyData = currentSpotifyOptions[idx];
+  const iframe = document.getElementById('spotify-iframe');
+  if (iframe) iframe.src = currentSpotifyData.embedUrl;
+  document.querySelectorAll('.spotify-option-btn').forEach((btn, i) => {
+    btn.classList.toggle('active', i === idx);
+  });
+  const saveBtn = document.querySelector('.spotify-save-btn');
+  if (saveBtn) {
+    const isSaved = sessionGame?.spotifyEmbedUrl === currentSpotifyData.embedUrl;
+    saveBtn.textContent = isSaved ? 'Saved ✓' : 'Save';
+    saveBtn.classList.toggle('saved', isSaved);
+  }
 }
 
 function renderSpotifyNoResult(container) {
@@ -634,19 +660,15 @@ async function searchSpotifyQuery() {
   if (!query) return;
 
   const container = document.getElementById('spotify-container');
-  const searchRow = document.getElementById('spotify-search-row');
   const queryValue = query;
 
-  // Swap iframe for a loading message but keep search row markup so we can restore it
   container.innerHTML = '<p class="no-players-msg">Searching…</p>';
 
   try {
     const res = await fetch(`/api/spotify/playlist?query=${encodeURIComponent(queryValue)}`);
     const data = await res.json();
-    if (data.embedUrl) {
-      currentSpotifyData = data;
-      renderSpotifyEmbed(container, data, false);
-      // Re-show search row with previous query
+    if (data.playlists?.length) {
+      renderSpotifyOptions(container, data.playlists, 0, false);
       showSpotifySearch();
       const newInput = document.getElementById('spotify-query-input');
       if (newInput) { newInput.value = queryValue; newInput.focus(); }

--- a/server.js
+++ b/server.js
@@ -70,11 +70,12 @@ async function handleSpotifyPlaylist(req, res) {
       res.end(JSON.stringify({ error: "No playlist found" }));
       return;
     }
-    const playlist = playlists[0];
     res.writeHead(200, { "Content-Type": "application/json" });
     res.end(JSON.stringify({
-      embedUrl: `https://open.spotify.com/embed/playlist/${playlist.id}?utm_source=generator&theme=0`,
-      name: playlist.name,
+      playlists: playlists.slice(0, 5).map(p => ({
+        embedUrl: `https://open.spotify.com/embed/playlist/${p.id}?utm_source=generator&theme=0`,
+        name: p.name,
+      })),
     }));
   } catch (err) {
     console.error(err);

--- a/style.css
+++ b/style.css
@@ -1343,6 +1343,38 @@ button:hover {
   display: block;
 }
 
+.spotify-options {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  margin-top: 0.35rem;
+}
+
+.spotify-option-btn {
+  text-align: left;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 5px;
+  color: #6a7a90;
+  font-size: 0.72rem;
+  padding: 0.2rem 0.4rem;
+  cursor: pointer;
+  width: 100%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.spotify-option-btn:hover {
+  color: #e0e0e0;
+  border-color: #1a4a80;
+}
+
+.spotify-option-btn.active {
+  color: #f5c842;
+  border-color: #1a4a80;
+}
+
 .spotify-meta {
   display: flex;
   align-items: center;
@@ -1350,14 +1382,6 @@ button:hover {
   margin-top: 0.4rem;
 }
 
-.spotify-playlist-name {
-  flex: 1;
-  font-size: 0.72rem;
-  color: #6a7a90;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
 
 .spotify-actions {
   display: flex;


### PR DESCRIPTION
Closes #50

## Summary
- Server accepts an optional `?query=` param — if provided, skips the auto-generated query entirely and passes it straight to Spotify search
- After any playlist loads in the session modal, the playlist name appears below the embed with **Change** and **Save** buttons
- **Change** toggles an inline search row; typing and hitting Enter (or clicking Search) re-queries Spotify with whatever the user typed — search row stays visible for further tweaking
- **Save** writes `spotifyEmbedUrl` + `spotifyPlaylistName` to the game object in `sz-games`; next time that game opens, the saved playlist renders immediately without a network call
- Saved state shown by a green "Saved ✓" button

## Test plan
- [ ] Open a session — auto-suggested playlist loads with name + Change + Save below
- [ ] Click Change — search row appears; type a query and hit Enter — new playlist loads
- [ ] Search row stays open after a successful custom search for further tweaking
- [ ] Click Save — button turns "Saved ✓"; close and reopen the session — saved playlist loads instantly
- [ ] Game with no match: no-result message with search row shown immediately
- [ ] Restart server — `?query=` param returns results for the custom string

🤖 Generated with [Claude Code](https://claude.com/claude-code)