### PR TITLE
Add players to an in-progress session

### DIFF
--- a/app.js
+++ b/app.js
@@ -703,12 +703,35 @@ function closeSession() {
 function removeSessionPlayer(index) {
   sessionPlayers.splice(index, 1);
   renderSessionPlayers();
+  renderScoreTracker();
+}
+
+function addSessionPlayer(select) {
+  const id = select.value;
+  if (!id) return;
+  const player = vault.find(p => p.id === id);
+  if (!player || sessionPlayers.some(p => p.id === id)) return;
+  sessionPlayers.push(player);
+  if (!(player.id in sessionScores)) sessionScores[player.id] = 0;
+  renderSessionPlayers();
+  renderScoreTracker();
 }
 
 function renderSessionPlayers() {
   const container = document.getElementById('session-player-list');
+  const sessionIds = new Set(sessionPlayers.map(p => p.id));
+  const available = vault.filter(p => !sessionIds.has(p.id));
+
+  const addRow = available.length > 0 ? `
+    <div class="add-player-row">
+      <select onchange="addSessionPlayer(this)">
+        <option value="">＋ Add player…</option>
+        ${available.map(p => `<option value="${p.id}">${p.name}</option>`).join('')}
+      </select>
+    </div>` : '';
+
   if (sessionPlayers.length === 0) {
-    container.innerHTML = '<p class="no-players-msg">No players on the Roll Call — tap players above to add them.</p>';
+    container.innerHTML = `<p class="no-players-msg">No players — add someone below.</p>${addRow}`;
     return;
   }
   container.innerHTML = sessionPlayers.map((p, i) => `
@@ -717,7 +740,7 @@ function renderSessionPlayers() {
       <span class="player-name">${p.name}</span>
       <button class="player-remove" onclick="removeSessionPlayer(${i})">×</button>
     </div>
-  `).join('');
+  `).join('') + addRow;
 }
 
 // ── Score Tracker ──────────────────────────────────────────────────────────

--- a/style.css
+++ b/style.css
@@ -589,6 +589,27 @@ button:hover {
   opacity: 1;
 }
 
+.add-player-row {
+  margin-top: 0.4rem;
+}
+
+.add-player-row select {
+  width: 100%;
+  background: #0f3460;
+  border: 1px dashed #1a4a80;
+  border-radius: 8px;
+  color: #6a7a90;
+  font-size: 0.82rem;
+  padding: 0.35rem 0.5rem;
+  cursor: pointer;
+}
+
+.add-player-row select:focus {
+  outline: none;
+  border-color: #f5c842;
+  color: #e0e0e0;
+}
+
 /* ── Expanded Game Card ──────────────────────────────────────────────────── */
 .game-card {
   cursor: pointer;


### PR DESCRIPTION
Closes #44

## Summary
- A `＋ Add player…` dropdown appears at the bottom of the Playing list in the session modal
- Only shows vault members not already in the session
- Selecting one adds them immediately with a score of 0 and re-renders both the player list and score tracker
- Dropdown disappears automatically when all vault members are already in the session
- Also fixes a minor bug: removing a player now correctly re-renders the score tracker (previously only the player list updated)

## Test plan
- [ ] Open a session with some players — dropdown shows the rest of the vault
- [ ] Select a player — they appear in the list and score tracker immediately
- [ ] All vault members in session — dropdown is gone
- [ ] Remove a player — score tracker updates correctly
- [ ] Pause and resume — added/removed players persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)