### PR TITLE
Game library — browse and edit full collection

### DIFF
--- a/app.js
+++ b/app.js
@@ -1430,6 +1430,199 @@ function saveFeedbackNotes(val) {
 }
 
 
+// ── Game Library ───────────────────────────────────────────────────────────
+let librarySortKey = 'name';
+let librarySortDir = 1;   // 1 = asc, -1 = desc
+let libraryDisplayed = []; // { game, idx } — maps display rows back to games[]
+
+const GAME_TYPES       = ['Abstract','Board','Card','Dice','Mystery','Narrative','Party'];
+const GAME_COMPLEXITIES = ['Low','Medium','High'];
+
+function openLibrary() {
+  renderLibrary();
+  document.getElementById('library-modal').classList.add('active');
+  document.getElementById('library-search').focus();
+}
+
+function closeLibrary() {
+  document.getElementById('library-modal').classList.remove('active');
+  const form = document.getElementById('add-game-form');
+  if (form) form.classList.add('hidden');
+}
+
+function setLibrarySort(key) {
+  if (librarySortKey === key) {
+    librarySortDir *= -1;
+  } else {
+    librarySortKey = key;
+    librarySortDir = key === 'rating' ? -1 : 1; // rating defaults desc
+  }
+  document.querySelectorAll('.lib-sort-btn').forEach(b => b.classList.remove('active'));
+  document.getElementById(`lib-sort-${key}`)?.classList.add('active');
+  renderLibrary();
+}
+
+function renderLibrary() {
+  const query = document.getElementById('library-search')?.value.trim().toLowerCase() || '';
+
+  let list = games.map((game, idx) => ({ game, idx }));
+
+  if (query) {
+    list = list.filter(({ game }) => game.name.toLowerCase().includes(query));
+  }
+
+  list.sort((a, b) => {
+    let va, vb;
+    if (librarySortKey === 'name')    { va = a.game.name; vb = b.game.name; return librarySortDir * va.localeCompare(vb); }
+    if (librarySortKey === 'rating')  { va = a.game.rating ?? 0; vb = b.game.rating ?? 0; }
+    if (librarySortKey === 'players') { va = a.game.maxPlayers; vb = b.game.maxPlayers; }
+    if (librarySortKey === 'time')    { va = a.game.playTime; vb = b.game.playTime; }
+    return librarySortDir * (va - vb);
+  });
+
+  libraryDisplayed = list;
+
+  const countEl = document.getElementById('library-count');
+  if (countEl) countEl.textContent = `${list.length} of ${games.length} game${games.length !== 1 ? 's' : ''}`;
+
+  const container = document.getElementById('library-list');
+  if (!container) return;
+
+  if (list.length === 0) {
+    container.innerHTML = '<p class="no-players-msg">No games match your search.</p>';
+    return;
+  }
+
+  container.innerHTML = list.map(({ game, idx }, di) => {
+    const thumb = game.thumbnail
+      ? `<img class="lib-thumb" src="${game.thumbnail}" alt="" loading="lazy" />`
+      : `<div class="lib-thumb lib-thumb-initials">${game.name.charAt(0).toUpperCase()}</div>`;
+
+    const stars = [1,2,3,4,5].map(n =>
+      `<span class="lib-star${(game.rating ?? 0) >= n ? ' filled' : ''}" onclick="setGameRating(${di}, ${n})"
+        title="${n} star${n>1?'s':''}">★</span>`
+    ).join('');
+
+    const players = game.minPlayers === game.maxPlayers
+      ? `${game.minPlayers}p`
+      : `${game.minPlayers}–${game.maxPlayers}p`;
+
+    const time = game.playTime >= 999 ? '∞' : `${game.playTime}m`;
+
+    const spotifyBadge = game.spotifyPlaylistName
+      ? `<span class="lib-badge lib-spotify-badge" title="${game.spotifyPlaylistName.replace(/"/g,'&quot;')}">♫</span>`
+      : '';
+
+    const bggLink = game.bggId
+      ? `<a class="lib-badge lib-bgg-badge" href="https://boardgamegeek.com/boardgame/${game.bggId}" target="_blank" rel="noopener">BGG↗</a>`
+      : '';
+
+    return `
+      <div class="lib-row">
+        ${thumb}
+        <div class="lib-info">
+          <div class="lib-name">${game.name}</div>
+          <div class="lib-meta">${players} · ${time} · Ages ${game.age}+</div>
+        </div>
+        <div class="lib-controls">
+          <div class="lib-rating">${stars}</div>
+          <button class="lib-tag lib-type-tag" onclick="cycleGameField(${di},'type')" title="Click to change type">${game.type}</button>
+          <button class="lib-tag lib-complexity-tag lib-complexity-${(game.complexity||'Medium').toLowerCase()}" onclick="cycleGameField(${di},'complexity')" title="Click to change complexity">${game.complexity}</button>
+          <button class="lib-toggle${game.cooperative ? ' on' : ''}" onclick="toggleGameField(${di},'cooperative')">Co-op</button>
+          <button class="lib-toggle${game.played ? ' on' : ''}" onclick="toggleGameField(${di},'played')">Played</button>
+          ${spotifyBadge}${bggLink}
+          <button class="lib-delete" onclick="deleteGame(${di})" title="Remove from library">×</button>
+        </div>
+      </div>`;
+  }).join('');
+}
+
+function saveGames() {
+  localStorage.setItem('sz-games', JSON.stringify(games));
+}
+
+function setGameRating(displayIdx, n) {
+  const { game, idx } = libraryDisplayed[displayIdx];
+  // clicking the same star again clears the rating
+  games[idx].rating = game.rating === n ? null : n;
+  saveGames();
+  renderLibrary();
+}
+
+function cycleGameField(displayIdx, field) {
+  const { game, idx } = libraryDisplayed[displayIdx];
+  if (field === 'type') {
+    const i = GAME_TYPES.indexOf(game.type);
+    games[idx].type = GAME_TYPES[(i + 1) % GAME_TYPES.length];
+  } else if (field === 'complexity') {
+    const i = GAME_COMPLEXITIES.indexOf(game.complexity);
+    games[idx].complexity = GAME_COMPLEXITIES[(i + 1) % GAME_COMPLEXITIES.length];
+  }
+  saveGames();
+  renderLibrary();
+}
+
+function toggleGameField(displayIdx, field) {
+  const { idx } = libraryDisplayed[displayIdx];
+  games[idx][field] = !games[idx][field];
+  saveGames();
+  renderLibrary();
+}
+
+function deleteGame(displayIdx) {
+  const { game, idx } = libraryDisplayed[displayIdx];
+  if (!confirm(`Remove "${game.name}" from your library?`)) return;
+  games.splice(idx, 1);
+  saveGames();
+  renderLibrary();
+}
+
+function toggleAddGameForm() {
+  const form = document.getElementById('add-game-form');
+  const isHidden = form.classList.toggle('hidden');
+  if (!isHidden) document.getElementById('ag-name')?.focus();
+}
+
+function submitAddGame() {
+  const name = document.getElementById('ag-name')?.value.trim();
+  if (!name) {
+    document.getElementById('ag-name')?.classList.add('input-error');
+    setTimeout(() => document.getElementById('ag-name')?.classList.remove('input-error'), 1200);
+    return;
+  }
+  if (games.some(g => g.name.toLowerCase() === name.toLowerCase())) {
+    alert(`"${name}" is already in your library.`);
+    return;
+  }
+  const minPlayers = parseInt(document.getElementById('ag-min-players')?.value) || 2;
+  const maxPlayers = parseInt(document.getElementById('ag-max-players')?.value) || minPlayers;
+  games.push({
+    name,
+    type:       document.getElementById('ag-type')?.value || 'Board',
+    complexity: document.getElementById('ag-complexity')?.value || 'Medium',
+    minPlayers,
+    maxPlayers,
+    playTime:   parseInt(document.getElementById('ag-playtime')?.value) || 60,
+    age:        parseInt(document.getElementById('ag-age')?.value) || 0,
+    setupTime:  10,
+    cooperative: document.getElementById('ag-coop')?.checked || false,
+    rating:     null,
+    played:     false,
+    thumbnail:  null,
+    bggId:      null,
+  });
+  saveGames();
+  // reset form
+  ['ag-name','ag-min-players','ag-max-players','ag-playtime','ag-age'].forEach(id => {
+    const el = document.getElementById(id); if (el) el.value = '';
+  });
+  document.getElementById('ag-coop').checked = false;
+  toggleAddGameForm();
+  // sort by name and re-render
+  librarySortKey = 'name'; librarySortDir = 1;
+  renderLibrary();
+}
+
 // ── Timer ──────────────────────────────────────────────────────────────────
 function toggleTimer() {
   if (timerInterval) {

--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
           <button class="vault-btn" onclick="openSettings()">⚙ Settings</button>
           <button class="vault-btn" onclick="openHistory()">History</button>
           <button class="vault-btn" onclick="openStats()">Stats</button>
+          <button class="vault-btn" onclick="openLibrary()">My Games</button>
           <button class="vault-btn" onclick="openVault()">Player Vault</button>
         </div>
       </div>
@@ -319,6 +320,56 @@
         </div>
         <div id="h2h-result" class="h2h-result"></div>
       </div>
+    </div>
+  </div>
+
+  <!-- Library Modal -->
+  <div id="library-modal" class="modal-overlay" onclick="closeLibrary()">
+    <div class="modal-panel library-panel" onclick="event.stopPropagation()">
+      <div class="modal-header">
+        <div class="session-title">My Games</div>
+        <button class="modal-close" onclick="closeLibrary()">×</button>
+      </div>
+      <div class="library-toolbar">
+        <input type="text" id="library-search" placeholder="🔍 Search…" oninput="renderLibrary()" autocomplete="off" />
+        <div class="library-sort-btns">
+          <button class="lib-sort-btn active" id="lib-sort-name" onclick="setLibrarySort('name')">Name</button>
+          <button class="lib-sort-btn" id="lib-sort-rating" onclick="setLibrarySort('rating')">Rating</button>
+          <button class="lib-sort-btn" id="lib-sort-players" onclick="setLibrarySort('players')">Players</button>
+          <button class="lib-sort-btn" id="lib-sort-time" onclick="setLibrarySort('time')">Time</button>
+        </div>
+        <button class="lib-add-btn" onclick="toggleAddGameForm()">+ Add Game</button>
+      </div>
+      <div id="add-game-form" class="add-game-form hidden">
+        <div class="add-game-fields">
+          <input type="text" id="ag-name" placeholder="Game name*" />
+          <select id="ag-type">
+            <option value="Board">Board</option>
+            <option value="Card">Card</option>
+            <option value="Party">Party</option>
+            <option value="Abstract">Abstract</option>
+            <option value="Dice">Dice</option>
+            <option value="Mystery">Mystery</option>
+            <option value="Narrative">Narrative</option>
+          </select>
+          <select id="ag-complexity">
+            <option value="Low">Low</option>
+            <option value="Medium" selected>Medium</option>
+            <option value="High">High</option>
+          </select>
+          <input type="number" id="ag-min-players" min="1" max="20" placeholder="Min players" />
+          <input type="number" id="ag-max-players" min="1" max="20" placeholder="Max players" />
+          <input type="number" id="ag-playtime" min="0" placeholder="Play time (min)" />
+          <input type="number" id="ag-age" min="0" placeholder="Min age" />
+          <label class="ag-coop-label"><input type="checkbox" id="ag-coop" /> Co-op</label>
+        </div>
+        <div class="add-game-actions">
+          <button class="ag-submit-btn" onclick="submitAddGame()">Add Game</button>
+          <button class="ag-cancel-btn" onclick="toggleAddGameForm()">Cancel</button>
+        </div>
+      </div>
+      <div id="library-count" class="library-count"></div>
+      <div id="library-list" class="library-list"></div>
     </div>
   </div>
 

--- a/style.css
+++ b/style.css
@@ -1955,3 +1955,292 @@ body.hide-why .why-btn {
 
 .bgg-sync-ok    { color: #5dd67a; }
 .bgg-sync-error { color: #e05252; }
+
+/* ── Game Library ────────────────────────────────────────────────────────── */
+.library-panel {
+  width: 95vw;
+  max-width: 860px;
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.library-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0 0 0.75rem;
+  flex-wrap: wrap;
+}
+
+.library-toolbar input {
+  flex: 1;
+  min-width: 120px;
+  background: #0f3460;
+  border: 1px solid #1a4a80;
+  border-radius: 8px;
+  color: #e0e0e0;
+  font-size: 0.88rem;
+  padding: 0.4rem 0.7rem;
+}
+
+.library-toolbar input:focus {
+  outline: none;
+  border-color: #f5c842;
+}
+
+.library-sort-btns {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.lib-sort-btn {
+  padding: 0.3rem 0.6rem;
+  background: transparent;
+  border: 1px solid #1a4a80;
+  border-radius: 6px;
+  color: #6a7a90;
+  font-size: 0.75rem;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.lib-sort-btn.active {
+  border-color: #f5c842;
+  color: #f5c842;
+}
+
+.lib-add-btn {
+  padding: 0.3rem 0.75rem;
+  background: #f5c842;
+  color: #1a1a2e;
+  border: none;
+  border-radius: 6px;
+  font-size: 0.8rem;
+  font-weight: 700;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.lib-add-btn:hover { background: #ffd966; }
+
+.add-game-form {
+  background: #0f3460;
+  border: 1px solid #1a4a80;
+  border-radius: 10px;
+  padding: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.add-game-fields {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-bottom: 0.5rem;
+}
+
+.add-game-fields input,
+.add-game-fields select {
+  background: #16213e;
+  border: 1px solid #1a4a80;
+  border-radius: 6px;
+  color: #e0e0e0;
+  font-size: 0.82rem;
+  padding: 0.35rem 0.5rem;
+  min-width: 0;
+}
+
+#ag-name { flex: 2; min-width: 140px; }
+#ag-type, #ag-complexity { flex: 1; min-width: 100px; }
+#ag-min-players, #ag-max-players, #ag-age { flex: 1; min-width: 70px; }
+#ag-playtime { flex: 1; min-width: 80px; }
+
+.add-game-fields input:focus,
+.add-game-fields select:focus {
+  outline: none;
+  border-color: #f5c842;
+}
+
+.ag-coop-label {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.82rem;
+  color: #a0aab8;
+  white-space: nowrap;
+  padding: 0.35rem 0.1rem;
+}
+
+.add-game-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.ag-submit-btn {
+  padding: 0.35rem 0.9rem;
+  background: #f5c842;
+  color: #1a1a2e;
+  border: none;
+  border-radius: 6px;
+  font-size: 0.82rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.ag-cancel-btn {
+  padding: 0.35rem 0.9rem;
+  background: transparent;
+  border: 1px solid #1a4a80;
+  border-radius: 6px;
+  color: #6a7a90;
+  font-size: 0.82rem;
+  cursor: pointer;
+}
+
+.library-count {
+  font-size: 0.75rem;
+  color: #6a7a90;
+  margin-bottom: 0.4rem;
+}
+
+.library-list {
+  overflow-y: auto;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.lib-row {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.45rem 0.5rem;
+  border-radius: 8px;
+  background: #0f3460;
+  min-width: 0;
+}
+
+.lib-row:hover { background: #16213e; }
+
+.lib-thumb {
+  width: 40px;
+  height: 40px;
+  border-radius: 6px;
+  object-fit: cover;
+  flex-shrink: 0;
+}
+
+.lib-thumb-initials {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #1a4a80;
+  color: #f5c842;
+  font-weight: 700;
+  font-size: 1rem;
+}
+
+.lib-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.lib-name {
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: #e0e0e0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.lib-meta {
+  font-size: 0.72rem;
+  color: #6a7a90;
+  margin-top: 0.1rem;
+}
+
+.lib-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  flex-shrink: 0;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.lib-rating {
+  display: flex;
+  gap: 0.05rem;
+}
+
+.lib-star {
+  color: #1a4a80;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: color 0.1s;
+  line-height: 1;
+}
+
+.lib-star.filled { color: #f5c842; }
+.lib-star:hover  { color: #ffd966; }
+
+.lib-tag {
+  font-size: 0.68rem;
+  padding: 0.15rem 0.4rem;
+  border-radius: 4px;
+  border: 1px solid #1a4a80;
+  background: transparent;
+  color: #a0aab8;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.lib-tag:hover { border-color: #f5c842; color: #f5c842; }
+
+.lib-complexity-low    { border-color: #5dd67a; color: #5dd67a; }
+.lib-complexity-medium { border-color: #f5c842; color: #f5c842; }
+.lib-complexity-high   { border-color: #e05252; color: #e05252; }
+
+.lib-toggle {
+  font-size: 0.68rem;
+  padding: 0.15rem 0.4rem;
+  border-radius: 4px;
+  border: 1px solid #1a4a80;
+  background: transparent;
+  color: #6a7a90;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.lib-toggle.on {
+  background: #1a4a80;
+  color: #e0e0e0;
+  border-color: #1a4a80;
+}
+
+.lib-badge {
+  font-size: 0.68rem;
+  padding: 0.15rem 0.35rem;
+  border-radius: 4px;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.lib-spotify-badge { color: #1DB954; border: 1px solid #1DB954; }
+.lib-bgg-badge     { color: #6a7a90; border: 1px solid #1a4a80; }
+.lib-bgg-badge:hover { color: #f5c842; border-color: #f5c842; }
+
+.lib-delete {
+  background: none;
+  border: none;
+  color: #6a7a90;
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 0.1rem;
+  flex-shrink: 0;
+}
+
+.lib-delete:hover { color: #e05252; }


### PR DESCRIPTION
Closes #53

## Summary
Adds a **My Games** button to the header that opens a full-screen library modal over the entire collection.

### Per-game controls
| Control | Behaviour |
|---|---|
| ★ rating | Click to set 1–5; click the same star again to clear |
| Type badge | Click to cycle through all 7 types |
| Complexity badge | Click to cycle Low → Medium → High (colour-coded) |
| Co-op / Played toggles | Click to flip |
| ♫ badge | Shown if a Spotify playlist is saved for this game |
| BGG↗ | Opens BGG page in new tab if bggId is present |
| × | Removes game after confirmation |

### Other features
- Search by name, sort by Name / Rating / Players / Time (click active sort to reverse)
- Thumbnail from BGG CSV import shown; initials fallback otherwise
- Add game manually via inline form (name, type, complexity, players, time, age, co-op)
- All changes persist immediately to `sz-games`

## Test plan
- [ ] Open My Games — all loaded games appear
- [ ] Search filters the list; count updates
- [ ] Sort by each column; click again reverses order
- [ ] Set a star rating — persists after closing and reopening
- [ ] Cycle type and complexity — changes reflected on main planner
- [ ] Toggle Co-op / Played
- [ ] ♫ badge visible for games with saved Spotify playlists
- [ ] Add a manual game — appears in library and in Find Games
- [ ] Delete a game — removed from library and from planner

🤖 Generated with [Claude Code](https://claude.com/claude-code)