### PR TITLE
Refactor Playwright tests to Page Object Model

### DIFF
--- a/app.js
+++ b/app.js
@@ -115,11 +115,11 @@ function renderVaultList() {
       <span></span>
     </div>
     ${sorted.map(p => `
-      <div class="vault-row">
+      <div class="vault-row" data-testid="vault-player" data-player-id="${p.id}">
         ${avatarHtml(p, true)}
         <span class="vault-col-player">${p.name}</span>
         <span class="vault-col-date">${formatLastPlayed(p.lastPlayed)}</span>
-        <button class="player-remove" onclick="removeFromVault('${p.id}')">×</button>
+        <button class="player-remove" data-testid="vault-remove" onclick="removeFromVault('${p.id}')">×</button>
       </div>
     `).join('')}
   `;
@@ -146,7 +146,7 @@ function renderRollCall() {
   container.innerHTML = vault.map(p => {
     const active = rollCall.has(p.id);
     return `
-      <div class="roll-call-chip ${active ? 'active' : ''}" onclick="toggleRollCall('${p.id}')">
+      <div class="roll-call-chip ${active ? 'active' : ''}" data-testid="roll-call-chip" data-player-id="${p.id}" onclick="toggleRollCall('${p.id}')">
         ${avatarHtml(p)}
         <span class="player-name">${p.name}</span>
         ${active ? '<span class="check">✓</span>' : ''}
@@ -467,10 +467,11 @@ function renderResults(picked, heading) {
 
     const li = document.createElement("li");
     li.className = "game-card";
+    li.setAttribute('data-testid', 'game-card');
     li.innerHTML = `
       <div class="game-card-main">
         <div>
-          <div class="game-name">${game.name}</div>
+          <div class="game-name" data-testid="game-name">${game.name}</div>
           <div class="game-meta">
             <span>👥 ${playerCount}</span>
             <span>⏱ ${formatPlayTime(game.playTime)}</span>
@@ -482,7 +483,7 @@ function renderResults(picked, heading) {
         <div class="game-card-right">
           ${ratingHtml}
           <span class="badge ${badgeClass}">${game.complexity}</span>
-          <button class="why-btn" onclick="event.stopPropagation(); askWhy(this, ${JSON.stringify(game).replace(/"/g, '&quot;')}, ${JSON.stringify(filters).replace(/"/g, '&quot;')})">Why?</button>
+          <button class="why-btn" data-testid="why-btn" onclick="event.stopPropagation(); askWhy(this, ${JSON.stringify(game).replace(/"/g, '&quot;')}, ${JSON.stringify(filters).replace(/"/g, '&quot;')})">Why?</button>
         </div>
       </div>
       <div class="game-detail hidden">
@@ -491,7 +492,7 @@ function renderResults(picked, heading) {
           ${game.cooperative ? '<span class="coop-tag">🤝 Co-op</span>' : ''}
           <span>${game.played ? '✓ Played before' : '✨ New to us'}</span>
         </div>
-        <button class="lets-play-btn" onclick="event.stopPropagation(); openSession(${index})">Let's Play!</button>
+        <button class="lets-play-btn" data-testid="lets-play-btn" onclick="event.stopPropagation(); openSession(${index})">Let's Play!</button>
       </div>
       <div class="why-text hidden"></div>
     `;
@@ -1499,7 +1500,7 @@ function renderLibrary() {
       : `<div class="lib-thumb lib-thumb-initials">${game.name.charAt(0).toUpperCase()}</div>`;
 
     const stars = [1,2,3,4,5].map(n =>
-      `<span class="lib-star${(game.rating ?? 0) >= n ? ' filled' : ''}" onclick="setGameRating(${di}, ${n})"
+      `<span class="lib-star${(game.rating ?? 0) >= n ? ' filled' : ''}" data-testid="lib-star" onclick="setGameRating(${di}, ${n})"
         title="${n} star${n>1?'s':''}">★</span>`
     ).join('');
 
@@ -1518,7 +1519,7 @@ function renderLibrary() {
       : '';
 
     return `
-      <div class="lib-row">
+      <div class="lib-row" data-testid="lib-row">
         ${thumb}
         <div class="lib-info">
           <div class="lib-name">${game.name}</div>
@@ -1531,7 +1532,7 @@ function renderLibrary() {
           <button class="lib-toggle${game.cooperative ? ' on' : ''}" onclick="toggleGameField(${di},'cooperative')">Co-op</button>
           <button class="lib-toggle${game.played ? ' on' : ''}" onclick="toggleGameField(${di},'played')">Played</button>
           ${spotifyBadge}${bggLink}
-          <button class="lib-delete" onclick="deleteGame(${di})" title="Remove from library">×</button>
+          <button class="lib-delete" data-testid="lib-delete" onclick="deleteGame(${di})" title="Remove from library">×</button>
         </div>
       </div>`;
   }).join('');

--- a/index.html
+++ b/index.html
@@ -17,14 +17,14 @@
       <div class="roll-call-header">
         <h2 class="section-label">🎲 Roll Call</h2>
         <div class="roll-call-actions">
-          <button class="vault-btn" onclick="openSettings()">⚙ Settings</button>
-          <button class="vault-btn" onclick="openHistory()">History</button>
-          <button class="vault-btn" onclick="openStats()">Stats</button>
-          <button class="vault-btn" onclick="openLibrary()">My Games</button>
-          <button class="vault-btn" onclick="openVault()">Player Vault</button>
+          <button class="vault-btn" data-testid="btn-settings" onclick="openSettings()">⚙ Settings</button>
+          <button class="vault-btn" data-testid="btn-history" onclick="openHistory()">History</button>
+          <button class="vault-btn" data-testid="btn-stats" onclick="openStats()">Stats</button>
+          <button class="vault-btn" data-testid="btn-library" onclick="openLibrary()">My Games</button>
+          <button class="vault-btn" data-testid="btn-vault" onclick="openVault()">Player Vault</button>
         </div>
       </div>
-      <div id="roll-call-chips" class="roll-call-chips"></div>
+      <div id="roll-call-chips" data-testid="roll-call-chips" class="roll-call-chips"></div>
     </section>
 
     <section class="games-in-progress hidden" id="games-in-progress">
@@ -34,9 +34,11 @@
 
     <section class="quick-search">
       <div class="quick-search-row">
-        <input type="text" id="search-input" placeholder="🔍 Search by game name…"
+        <input type="text" id="search-input" data-testid="search-input"
+               placeholder="🔍 Search by game name…"
                oninput="onSearchInput()" autocomplete="off" />
-        <button class="search-clear-btn hidden" id="search-clear-btn" onclick="clearSearch()">×</button>
+        <button class="search-clear-btn hidden" id="search-clear-btn"
+                data-testid="search-clear-btn" onclick="clearSearch()">×</button>
       </div>
     </section>
 
@@ -44,12 +46,12 @@
       <div class="filter-row">
         <div class="field">
           <label for="players">Players</label>
-          <input type="number" id="players" min="1" max="20" placeholder="e.g. 4" />
+          <input type="number" id="players" data-testid="filter-players" min="1" max="20" placeholder="e.g. 4" />
         </div>
 
         <div class="field">
           <label for="playtime">Max Play Time</label>
-          <select id="playtime">
+          <select id="playtime" data-testid="filter-playtime">
             <option value="">Any</option>
             <option value="15">15 min</option>
             <option value="30">30 min</option>
@@ -63,7 +65,7 @@
 
         <div class="field">
           <label for="complexity">Complexity</label>
-          <select id="complexity">
+          <select id="complexity" data-testid="filter-complexity">
             <option value="">Any</option>
             <option value="Low">Low</option>
             <option value="Medium">Medium</option>
@@ -75,7 +77,7 @@
       <div class="filter-row">
         <div class="field">
           <label for="type">Game Type</label>
-          <select id="type">
+          <select id="type" data-testid="filter-type">
             <option value="">Any</option>
             <option value="Abstract">Abstract</option>
             <option value="Board">Board</option>
@@ -89,7 +91,7 @@
 
         <div class="field">
           <label for="age">Min Age ≤</label>
-          <select id="age">
+          <select id="age" data-testid="filter-age">
             <option value="">Any</option>
             <option value="5">5</option>
             <option value="6">6</option>
@@ -103,14 +105,15 @@
 
         <div class="field field-toggle">
           <label>New to Us</label>
-          <button id="new-only-btn" class="toggle-btn" onclick="toggleNewOnly()" aria-pressed="false">Off</button>
+          <button id="new-only-btn" data-testid="new-only-btn" class="toggle-btn"
+                  onclick="toggleNewOnly()" aria-pressed="false">Off</button>
         </div>
       </div>
 
       <div class="filter-row">
         <div class="field">
           <label for="setup">Max Setup</label>
-          <select id="setup">
+          <select id="setup" data-testid="filter-setup">
             <option value="">Any</option>
             <option value="5">≤ 5 min</option>
             <option value="15">≤ 15 min</option>
@@ -119,7 +122,7 @@
 
         <div class="field">
           <label for="min-rating">Min Rating</label>
-          <select id="min-rating">
+          <select id="min-rating" data-testid="filter-min-rating">
             <option value="">Any</option>
             <option value="3">★★★+</option>
             <option value="4">★★★★+</option>
@@ -129,52 +132,54 @@
 
         <div class="field field-toggle">
           <label>Co-op Only</label>
-          <button id="coop-btn" class="toggle-btn" onclick="toggleCoop()" aria-pressed="false">Off</button>
+          <button id="coop-btn" data-testid="coop-btn" class="toggle-btn"
+                  onclick="toggleCoop()" aria-pressed="false">Off</button>
         </div>
       </div>
 
       <div class="buttons">
-        <button id="suggest-btn" onclick="suggest()">Find Games</button>
-        <button id="surprise-btn" onclick="surprise()">🎲 Surprise Me</button>
+        <button id="suggest-btn" data-testid="btn-find-games" onclick="suggest()">Find Games</button>
+        <button id="surprise-btn" data-testid="btn-surprise" onclick="surprise()">🎲 Surprise Me</button>
       </div>
     </section>
 
-    <section id="results" class="results hidden">
+    <section id="results" data-testid="results" class="results hidden">
       <h2 id="results-heading">Suggested Games</h2>
-      <ul id="game-list"></ul>
+      <ul id="game-list" data-testid="game-list"></ul>
     </section>
 
-    <section id="no-results" class="no-results hidden">
+    <section id="no-results" data-testid="no-results" class="no-results hidden">
       <p>No games matched your filters. Try loosening the constraints!</p>
     </section>
   </div>
 
   <!-- Player Vault Modal -->
-  <div id="vault-modal" class="modal-overlay">
+  <div id="vault-modal" data-testid="vault-modal" class="modal-overlay">
     <div class="modal-panel">
       <div class="modal-header">
         <div class="session-title">Player Vault</div>
-        <button class="modal-close" onclick="closeVault()">×</button>
+        <button class="modal-close" data-testid="vault-modal-close" onclick="closeVault()">×</button>
       </div>
       <div class="modal-section">
         <div class="player-input-row">
-          <input type="text" id="vault-name-input" placeholder="Add a player..."
+          <input type="text" id="vault-name-input" data-testid="vault-name-input"
+                 placeholder="Add a player..."
                  onkeydown="if(event.key==='Enter') addToVault()" />
-          <button id="add-vault-btn" onclick="addToVault()">Add</button>
+          <button id="add-vault-btn" data-testid="vault-add-btn" onclick="addToVault()">Add</button>
         </div>
-        <div id="vault-list" class="vault-list"></div>
+        <div id="vault-list" data-testid="vault-list" class="vault-list"></div>
       </div>
     </div>
   </div>
 
   <!-- Session Modal -->
-  <div id="session-modal" class="modal-overlay">
+  <div id="session-modal" data-testid="session-modal" class="modal-overlay">
     <div class="modal-panel">
       <div class="modal-header">
-        <div id="session-game-title" class="session-title"></div>
+        <div id="session-game-title" data-testid="session-game-title" class="session-title"></div>
         <div class="modal-header-actions">
-          <button class="pause-btn" id="pause-btn" onclick="pauseSession()">Pause</button>
-          <button class="modal-close" onclick="closeSession()">×</button>
+          <button class="pause-btn" id="pause-btn" data-testid="pause-btn" onclick="pauseSession()">Pause</button>
+          <button class="modal-close" data-testid="session-modal-close" onclick="closeSession()">×</button>
         </div>
       </div>
       <div class="modal-cols">
@@ -183,7 +188,7 @@
             <div class="session-panels">
               <div class="modal-section">
                 <div class="modal-section-label">Playing</div>
-                <div id="session-player-list" class="session-player-list"></div>
+                <div id="session-player-list" data-testid="session-player-list" class="session-player-list"></div>
               </div>
               <div class="modal-section" id="score-section">
                 <div class="score-header">
@@ -196,9 +201,9 @@
                     </label>
                   </div>
                 </div>
-                <div id="score-list" class="score-list"></div>
-                <button class="end-game-btn" id="end-game-btn" onclick="endGame()">End Game</button>
-                <div id="winner-banner" class="winner-banner hidden"></div>
+                <div id="score-list" data-testid="score-list" class="score-list"></div>
+                <button class="end-game-btn" id="end-game-btn" data-testid="end-game-btn" onclick="endGame()">End Game</button>
+                <div id="winner-banner" data-testid="winner-banner" class="winner-banner hidden"></div>
               </div>
             </div>
             <div class="feedback-body" id="feedback-body">
@@ -218,7 +223,7 @@
                 <button class="back-btn" onclick="backToSession()">← Back</button>
                 <div class="feedback-finalize">
                   <p class="finalize-note">Finalize to save all results and feedback.</p>
-                  <button class="finalize-session-btn" onclick="finalizeSession()">Finalize Session</button>
+                  <button class="finalize-session-btn" data-testid="finalize-btn" onclick="finalizeSession()">Finalize Session</button>
                 </div>
               </div>
             </div>
@@ -227,15 +232,15 @@
         <div class="modal-right-col">
           <div class="modal-section">
             <div class="modal-section-label">Timer</div>
-            <div id="timer-display" class="timer-display">0:00:00</div>
+            <div id="timer-display" data-testid="timer-display" class="timer-display">0:00:00</div>
             <div class="timer-controls">
-              <button id="timer-toggle-btn" onclick="toggleTimer()">Start</button>
-              <button class="timer-reset-btn" onclick="resetTimer()">Reset</button>
+              <button id="timer-toggle-btn" data-testid="timer-toggle-btn" onclick="toggleTimer()">Start</button>
+              <button class="timer-reset-btn" data-testid="timer-reset-btn" onclick="resetTimer()">Reset</button>
             </div>
           </div>
           <div class="modal-section">
             <div class="modal-section-label">Music</div>
-            <div id="spotify-container" class="spotify-container">
+            <div id="spotify-container" data-testid="spotify-container" class="spotify-container">
               <p class="no-players-msg">Finding music…</p>
             </div>
           </div>
@@ -254,11 +259,11 @@
   </div>
 
   <!-- Settings Modal -->
-  <div id="settings-modal" class="modal-overlay" onclick="closeSettings()">
+  <div id="settings-modal" data-testid="settings-modal" class="modal-overlay" onclick="closeSettings()">
     <div class="modal-panel settings-panel" onclick="event.stopPropagation()">
       <div class="modal-header">
         <div class="session-title">Settings</div>
-        <button class="modal-close" onclick="closeSettings()">×</button>
+        <button class="modal-close" data-testid="settings-modal-close" onclick="closeSettings()">×</button>
       </div>
       <div class="settings-body">
         <div class="settings-group-label">BoardGameGeek</div>
@@ -268,9 +273,9 @@
             <div class="settings-row-desc">On BGG: go to your collection → Export → CSV. Import that file here.</div>
           </div>
           <label class="bgg-file-label" for="bgg-csv-input">Choose CSV file</label>
-          <input type="file" id="bgg-csv-input" accept=".csv" class="bgg-file-input"
-                 onchange="handleBGGImport(this)" />
-          <div id="bgg-sync-status" class="bgg-sync-status"></div>
+          <input type="file" id="bgg-csv-input" data-testid="bgg-csv-input" accept=".csv"
+                 class="bgg-file-input" onchange="handleBGGImport(this)" />
+          <div id="bgg-sync-status" data-testid="bgg-sync-status" class="bgg-sync-status"></div>
         </div>
 
         <div class="settings-group-label" style="margin-top:1rem">AI Features</div>
@@ -279,40 +284,43 @@
             <div class="settings-row-label">Why? Button</div>
             <div class="settings-row-desc">Ask Claude why a game fits tonight's group</div>
           </div>
-          <button id="setting-why-btn" class="toggle-btn" onclick="toggleSetting('showWhyBtn')" aria-pressed="true">On</button>
+          <button id="setting-why-btn" data-testid="setting-why-btn" class="toggle-btn"
+                  onclick="toggleSetting('showWhyBtn')" aria-pressed="true">On</button>
         </div>
       </div>
     </div>
   </div>
 
   <!-- History Modal -->
-  <div id="history-modal" class="modal-overlay" onclick="closeHistory()">
+  <div id="history-modal" data-testid="history-modal" class="modal-overlay" onclick="closeHistory()">
     <div class="modal-panel history-panel" onclick="event.stopPropagation()">
       <div class="modal-header">
         <div class="session-title">Play History</div>
-        <button class="modal-close" onclick="closeHistory()">×</button>
+        <button class="modal-close" data-testid="history-modal-close" onclick="closeHistory()">×</button>
       </div>
       <div class="history-body">
-        <div id="history-list" class="history-list"></div>
+        <div id="history-list" data-testid="history-list" class="history-list"></div>
       </div>
     </div>
   </div>
 
   <!-- Stats Modal -->
-  <div id="stats-modal" class="modal-overlay" onclick="closeStats()">
+  <div id="stats-modal" data-testid="stats-modal" class="modal-overlay" onclick="closeStats()">
     <div class="modal-panel stats-panel" onclick="event.stopPropagation()">
       <div class="modal-header">
         <div class="session-title">Player Stats</div>
-        <button class="modal-close" onclick="closeStats()">×</button>
+        <button class="modal-close" data-testid="stats-modal-close" onclick="closeStats()">×</button>
       </div>
       <div class="stats-tabs">
-        <button class="stats-tab active" id="tab-players" onclick="switchStatsTab('players')">Players</button>
-        <button class="stats-tab" id="tab-h2h" onclick="switchStatsTab('h2h')">Head-to-Head</button>
+        <button class="stats-tab active" id="tab-players" data-testid="tab-players"
+                onclick="switchStatsTab('players')">Players</button>
+        <button class="stats-tab" id="tab-h2h" data-testid="tab-h2h"
+                onclick="switchStatsTab('h2h')">Head-to-Head</button>
       </div>
-      <div class="stats-body" id="stats-body-players">
+      <div class="stats-body" id="stats-body-players" data-testid="stats-body-players">
         <div id="stats-list" class="stats-list"></div>
       </div>
-      <div class="stats-body hidden" id="stats-body-h2h">
+      <div class="stats-body hidden" id="stats-body-h2h" data-testid="stats-body-h2h">
         <div class="h2h-selectors">
           <div class="h2h-selector" id="h2h-selector-a"></div>
           <div class="h2h-vs">vs.</div>
@@ -324,26 +332,31 @@
   </div>
 
   <!-- Library Modal -->
-  <div id="library-modal" class="modal-overlay" onclick="closeLibrary()">
+  <div id="library-modal" data-testid="library-modal" class="modal-overlay" onclick="closeLibrary()">
     <div class="modal-panel library-panel" onclick="event.stopPropagation()">
       <div class="modal-header">
         <div class="session-title">My Games</div>
-        <button class="modal-close" onclick="closeLibrary()">×</button>
+        <button class="modal-close" data-testid="library-modal-close" onclick="closeLibrary()">×</button>
       </div>
       <div class="library-toolbar">
-        <input type="text" id="library-search" placeholder="🔍 Search…" oninput="renderLibrary()" autocomplete="off" />
+        <input type="text" id="library-search" data-testid="library-search"
+               placeholder="🔍 Search…" oninput="renderLibrary()" autocomplete="off" />
         <div class="library-sort-btns">
-          <button class="lib-sort-btn active" id="lib-sort-name" onclick="setLibrarySort('name')">Name</button>
-          <button class="lib-sort-btn" id="lib-sort-rating" onclick="setLibrarySort('rating')">Rating</button>
-          <button class="lib-sort-btn" id="lib-sort-players" onclick="setLibrarySort('players')">Players</button>
-          <button class="lib-sort-btn" id="lib-sort-time" onclick="setLibrarySort('time')">Time</button>
+          <button class="lib-sort-btn active" id="lib-sort-name" data-testid="lib-sort-name"
+                  onclick="setLibrarySort('name')">Name</button>
+          <button class="lib-sort-btn" id="lib-sort-rating" data-testid="lib-sort-rating"
+                  onclick="setLibrarySort('rating')">Rating</button>
+          <button class="lib-sort-btn" id="lib-sort-players" data-testid="lib-sort-players"
+                  onclick="setLibrarySort('players')">Players</button>
+          <button class="lib-sort-btn" id="lib-sort-time" data-testid="lib-sort-time"
+                  onclick="setLibrarySort('time')">Time</button>
         </div>
-        <button class="lib-add-btn" onclick="toggleAddGameForm()">+ Add Game</button>
+        <button class="lib-add-btn" data-testid="btn-add-game" onclick="toggleAddGameForm()">+ Add Game</button>
       </div>
-      <div id="add-game-form" class="add-game-form hidden">
+      <div id="add-game-form" data-testid="add-game-form" class="add-game-form hidden">
         <div class="add-game-fields">
-          <input type="text" id="ag-name" placeholder="Game name*" />
-          <select id="ag-type">
+          <input type="text" id="ag-name" data-testid="ag-name" placeholder="Game name*" />
+          <select id="ag-type" data-testid="ag-type">
             <option value="Board">Board</option>
             <option value="Card">Card</option>
             <option value="Party">Party</option>
@@ -352,24 +365,24 @@
             <option value="Mystery">Mystery</option>
             <option value="Narrative">Narrative</option>
           </select>
-          <select id="ag-complexity">
+          <select id="ag-complexity" data-testid="ag-complexity">
             <option value="Low">Low</option>
             <option value="Medium" selected>Medium</option>
             <option value="High">High</option>
           </select>
-          <input type="number" id="ag-min-players" min="1" max="20" placeholder="Min players" />
-          <input type="number" id="ag-max-players" min="1" max="20" placeholder="Max players" />
-          <input type="number" id="ag-playtime" min="0" placeholder="Play time (min)" />
-          <input type="number" id="ag-age" min="0" placeholder="Min age" />
-          <label class="ag-coop-label"><input type="checkbox" id="ag-coop" /> Co-op</label>
+          <input type="number" id="ag-min-players" data-testid="ag-min-players" min="1" max="20" placeholder="Min players" />
+          <input type="number" id="ag-max-players" data-testid="ag-max-players" min="1" max="20" placeholder="Max players" />
+          <input type="number" id="ag-playtime" data-testid="ag-playtime" min="0" placeholder="Play time (min)" />
+          <input type="number" id="ag-age" data-testid="ag-age" min="0" placeholder="Min age" />
+          <label class="ag-coop-label"><input type="checkbox" id="ag-coop" data-testid="ag-coop" /> Co-op</label>
         </div>
         <div class="add-game-actions">
-          <button class="ag-submit-btn" onclick="submitAddGame()">Add Game</button>
-          <button class="ag-cancel-btn" onclick="toggleAddGameForm()">Cancel</button>
+          <button class="ag-submit-btn" data-testid="ag-submit" onclick="submitAddGame()">Add Game</button>
+          <button class="ag-cancel-btn" data-testid="ag-cancel" onclick="toggleAddGameForm()">Cancel</button>
         </div>
       </div>
-      <div id="library-count" class="library-count"></div>
-      <div id="library-list" class="library-list"></div>
+      <div id="library-count" data-testid="library-count" class="library-count"></div>
+      <div id="library-list" data-testid="library-list" class="library-list"></div>
     </div>
   </div>
 

--- a/tests/app.spec.js
+++ b/tests/app.spec.js
@@ -1,7 +1,14 @@
 const { test, expect } = require('@playwright/test');
+const { MainPage }     = require('./pages/MainPage');
+const { VaultModal }   = require('./pages/VaultModal');
+const { SessionModal } = require('./pages/SessionModal');
+const { LibraryModal } = require('./pages/LibraryModal');
+const { SettingsModal } = require('./pages/SettingsModal');
+const { HistoryModal } = require('./pages/HistoryModal');
+const { StatsModal }   = require('./pages/StatsModal');
 
-// Each test gets a fresh localStorage so state doesn't bleed between tests.
-// After reloading we wait for games to finish loading from games.json (async fetch).
+// Each test gets a fresh localStorage so state doesn't bleed between runs.
+// waitForLoadState('networkidle') ensures games.json fetch completes first.
 test.beforeEach(async ({ page }) => {
   await page.goto('/');
   await page.evaluate(() => localStorage.clear());
@@ -10,226 +17,213 @@ test.beforeEach(async ({ page }) => {
 });
 
 // ── Page load ──────────────────────────────────────────────────────────────
-test('loads with correct title and header buttons', async ({ page }) => {
+test('loads with correct title and all header buttons', async ({ page }) => {
+  const main = new MainPage(page);
   await expect(page).toHaveTitle('Session Zero');
   await expect(page.getByText('Session Zero: A Game Night Planner')).toBeVisible();
-  await expect(page.getByRole('button', { name: 'Player Vault' })).toBeVisible();
-  await expect(page.getByRole('button', { name: 'My Games' })).toBeVisible();
-  await expect(page.getByRole('button', { name: 'History' })).toBeVisible();
-  await expect(page.getByRole('button', { name: 'Stats' })).toBeVisible();
-  await expect(page.getByRole('button', { name: /Settings/ })).toBeVisible();
+  await expect(main.btnVault).toBeVisible();
+  await expect(main.btnLibrary).toBeVisible();
+  await expect(main.btnHistory).toBeVisible();
+  await expect(main.btnStats).toBeVisible();
+  await expect(main.btnSettings).toBeVisible();
 });
 
 // ── Player Vault ───────────────────────────────────────────────────────────
 test('can add and remove a player from the vault', async ({ page }) => {
-  await page.getByRole('button', { name: 'Player Vault' }).click();
-  await expect(page.locator('#vault-modal')).toHaveClass(/active/);
-
-  await page.fill('#vault-name-input', 'Alice');
-  await page.getByRole('button', { name: 'Add' }).click();
-  await expect(page.locator('#vault-list')).toContainText('Alice');
-
-  // Remove the player
-  await page.locator('#vault-list').getByRole('button', { name: '×' }).click();
-  await expect(page.locator('#vault-list')).not.toContainText('Alice');
+  const vault = new VaultModal(page);
+  await vault.open();
+  await vault.addPlayer('Alice');
+  await vault.expectPlayer('Alice');
+  await vault.removePlayer('Alice');
+  await vault.expectNoPlayer('Alice');
 });
 
 test('rejects duplicate player names', async ({ page }) => {
-  await page.getByRole('button', { name: 'Player Vault' }).click();
-  await page.fill('#vault-name-input', 'Bob');
-  await page.getByRole('button', { name: 'Add' }).click();
-
-  await page.fill('#vault-name-input', 'bob');
-  await page.getByRole('button', { name: 'Add' }).click();
-  // Name should still only appear once
-  await expect(page.locator('#vault-list').getByText('Bob')).toHaveCount(1);
+  const vault = new VaultModal(page);
+  await vault.open();
+  await vault.addPlayer('Bob');
+  await vault.addPlayer('bob'); // duplicate — different case
+  await expect(vault.list.getByTestId('vault-player').filter({ hasText: 'Bob' })).toHaveCount(1);
 });
 
 // ── Roll Call ──────────────────────────────────────────────────────────────
 test('toggling a player on roll call updates the player count filter', async ({ page }) => {
-  // Add a player to the vault first
-  await page.getByRole('button', { name: 'Player Vault' }).click();
-  await page.fill('#vault-name-input', 'Carol');
-  await page.getByRole('button', { name: 'Add' }).click();
-  await page.locator('#vault-modal .modal-close').click();
+  const vault = new VaultModal(page);
+  const main  = new MainPage(page);
 
-  // Toggle Carol onto the roll call
-  const chip = page.locator('#roll-call-chips .roll-call-chip', { hasText: 'Carol' });
+  await vault.open();
+  await vault.addPlayer('Carol');
+  await vault.close();
+
+  const chip = main.rollCallChip('Carol');
   await chip.click();
   await expect(chip).toHaveClass(/active/);
+  await expect(main.playersInput).toHaveValue('1');
 
-  // Players filter should auto-fill to 1
-  await expect(page.locator('#players')).toHaveValue('1');
-
-  // Toggle off
   await chip.click();
   await expect(chip).not.toHaveClass(/active/);
 });
 
 // ── Find Games / Filters ───────────────────────────────────────────────────
 test('Find Games shows results from games.json', async ({ page }) => {
-  await page.getByRole('button', { name: 'Find Games' }).click();
-  await expect(page.locator('#results')).not.toHaveClass(/hidden/);
-  const items = page.locator('#game-list li');
-  await expect(items).not.toHaveCount(0);
+  const main = new MainPage(page);
+  await main.findGames();
+  await main.expectResults();
+  await expect(main.gameCards()).not.toHaveCount(0);
 });
 
 test('filtering by player count narrows results', async ({ page }) => {
-  await page.getByRole('button', { name: 'Find Games' }).click();
-  const allCount = await page.locator('#game-list li').count();
+  const main = new MainPage(page);
+  await main.findGames();
+  const allCount = await main.gameCards().count();
 
-  await page.fill('#players', '2');
-  await page.getByRole('button', { name: 'Find Games' }).click();
-  const filteredCount = await page.locator('#game-list li').count();
-
+  await main.setPlayers(2);
+  await main.findGames();
+  await main.expectResults();
+  const filteredCount = await main.gameCards().count();
   expect(filteredCount).toBeGreaterThan(0);
   expect(filteredCount).toBeLessThanOrEqual(allCount);
 });
 
-test('filtering by complexity narrows results', async ({ page }) => {
-  await page.selectOption('#complexity', 'Low');
-  await page.getByRole('button', { name: 'Find Games' }).click();
-  const items = page.locator('#game-list li');
-  const count = await items.count();
+test('filtering by complexity narrows results and all badges match', async ({ page }) => {
+  const main = new MainPage(page);
+  await main.setComplexity('Low');
+  await main.findGames();
+  await main.expectResults();
+  const count = await main.gameCards().count();
   expect(count).toBeGreaterThan(0);
-  // Every visible badge should be Low
-  const badges = await page.locator('#game-list .badge-low').count();
+  const badges = await page.locator('[data-testid="game-list"] .badge-low').count();
   expect(badges).toBe(count);
 });
 
 test('no-results message shown when filters match nothing', async ({ page }) => {
-  await page.fill('#players', '99');
-  await page.getByRole('button', { name: 'Find Games' }).click();
-  await expect(page.locator('#no-results')).not.toHaveClass(/hidden/);
+  const main = new MainPage(page);
+  await main.setPlayers(99);
+  await main.findGames();
+  await main.expectNoResults();
 });
 
 test('Surprise Me shows exactly 1 game', async ({ page }) => {
-  await page.getByRole('button', { name: '🎲 Surprise Me' }).click();
-  await expect(page.locator('#results')).not.toHaveClass(/hidden/);
-  await expect(page.locator('#game-list li')).toHaveCount(1);
+  const main = new MainPage(page);
+  await main.surpriseMe();
+  await main.expectResults();
+  await expect(main.gameCards()).toHaveCount(1);
 });
 
 // ── Quick Search ───────────────────────────────────────────────────────────
 test('quick search filters visible games', async ({ page }) => {
-  await page.getByRole('button', { name: 'Find Games' }).click();
-  const totalBefore = await page.locator('#game-list li').count();
+  const main = new MainPage(page);
+  await main.findGames();
+  const totalBefore = await main.gameCards().count();
 
-  await page.fill('#search-input', 'wing');
-  const afterCount = await page.locator('#game-list li').count();
+  await main.search('wing');
+  const afterCount = await main.gameCards().count();
+  expect(afterCount).toBeGreaterThan(0);
   expect(afterCount).toBeLessThan(totalBefore);
-  // Every visible game name should contain the search string (case-insensitive)
-  const names = await page.locator('#game-list .game-name').allTextContents();
+
+  const names = await page.getByTestId('game-name').allTextContents();
   for (const name of names) {
     expect(name.toLowerCase()).toContain('wing');
   }
 });
 
 // ── Session Modal ──────────────────────────────────────────────────────────
-test('Let\'s Play opens session modal with game title', async ({ page }) => {
-  await page.getByRole('button', { name: 'Find Games' }).click();
-  await page.locator('#game-list li').first().click(); // expand card
-  await page.locator('.lets-play-btn').first().click();
-  await expect(page.locator('#session-modal')).toHaveClass(/active/);
-  // Title is set
-  await expect(page.locator('#session-game-title')).not.toBeEmpty();
+test("Let's Play opens session modal with game title", async ({ page }) => {
+  const main    = new MainPage(page);
+  const session = new SessionModal(page);
+
+  await main.findGames();
+  await main.letsPlay(0);
+
+  await session.expectOpen();
+  await expect(session.title).not.toBeEmpty();
 });
 
-test('timer starts and stops', async ({ page }) => {
-  await page.getByRole('button', { name: 'Find Games' }).click();
-  await page.locator('#game-list li').first().click();
-  await page.locator('.lets-play-btn').first().click();
+test('timer starts and pauses', async ({ page }) => {
+  const main    = new MainPage(page);
+  const session = new SessionModal(page);
 
-  await page.locator('#timer-toggle-btn').click(); // Start
+  await main.findGames();
+  await main.letsPlay(0);
+
+  await session.startTimer();
   await page.waitForTimeout(1200);
-  const display = await page.locator('#timer-display').textContent();
+  const display = await session.timerDisplay.textContent();
   expect(display).not.toBe('0:00:00');
 
-  await page.locator('#timer-toggle-btn').click(); // Pause
-  const frozen = await page.locator('#timer-display').textContent();
+  await session.pauseTimer();
+  const frozen = await session.timerDisplay.textContent();
   await page.waitForTimeout(600);
-  await expect(page.locator('#timer-display')).toHaveText(frozen);
+  await expect(session.timerDisplay).toHaveText(frozen);
 });
 
 // ── Game Library ───────────────────────────────────────────────────────────
 test('library shows loaded games and correct count', async ({ page }) => {
-  await page.getByRole('button', { name: 'My Games' }).click();
-  await expect(page.locator('#library-modal')).toHaveClass(/active/);
-  const countText = await page.locator('#library-count').textContent();
-  expect(countText).toMatch(/\d+ of \d+ games?/);
-  await expect(page.locator('#library-list .lib-row').first()).toBeVisible();
+  const library = new LibraryModal(page);
+  await library.open();
+  await expect(library.count).toHaveText(/\d+ of \d+ games?/);
+  await expect(library.rows().first()).toBeVisible();
 });
 
 test('library search filters rows', async ({ page }) => {
-  await page.getByRole('button', { name: 'My Games' }).click();
-  const totalRows = await page.locator('#library-list .lib-row').count();
+  const library = new LibraryModal(page);
+  await library.open();
+  const totalRows = await library.rows().count();
 
-  await page.fill('#library-search', 'wingspan');
-  const filtered = await page.locator('#library-list .lib-row').count();
+  await library.search('wingspan');
+  const filtered = await library.rows().count();
   expect(filtered).toBeGreaterThan(0);
   expect(filtered).toBeLessThan(totalRows);
 });
 
 test('can add a game manually in the library', async ({ page }) => {
-  await page.getByRole('button', { name: 'My Games' }).click();
-  await page.getByRole('button', { name: '+ Add Game' }).click();
-  await expect(page.locator('#add-game-form')).not.toHaveClass(/hidden/);
-
-  await page.fill('#ag-name', 'Test Game XYZ');
-  await page.fill('#ag-min-players', '2');
-  await page.fill('#ag-max-players', '4');
-  await page.fill('#ag-playtime', '45');
-  await page.locator('.ag-submit-btn').click();
-
-  await expect(page.locator('#library-list')).toContainText('Test Game XYZ');
+  const library = new LibraryModal(page);
+  await library.open();
+  await library.addGame({ name: 'Test Game XYZ', minPlayers: '2', maxPlayers: '4', playtime: '45' });
+  await library.expectGame('Test Game XYZ');
 });
 
 test('can delete a game from the library', async ({ page }) => {
-  // Add a throwaway game first
-  await page.getByRole('button', { name: 'My Games' }).click();
-  await page.getByRole('button', { name: '+ Add Game' }).click();
-  await page.fill('#ag-name', 'DeleteMe Game');
-  await page.locator('.ag-submit-btn').click();
+  const library = new LibraryModal(page);
+  await library.open();
+  await library.addGame({ name: 'DeleteMe Game' });
 
-  // Set up dialog handler before clicking delete
   page.on('dialog', d => d.accept());
-  const row = page.locator('#library-list .lib-row', { hasText: 'DeleteMe Game' });
-  await row.locator('.lib-delete').click();
-  await expect(page.locator('#library-list')).not.toContainText('DeleteMe Game');
+  await library.deleteGame('DeleteMe Game');
+  await library.expectNoGame('DeleteMe Game');
 });
 
 // ── Settings ───────────────────────────────────────────────────────────────
 test('settings modal opens and Why? toggle works', async ({ page }) => {
-  await page.getByRole('button', { name: /Settings/ }).click();
-  await expect(page.locator('#settings-modal')).toHaveClass(/active/);
+  const settings = new SettingsModal(page);
+  const main     = new MainPage(page);
 
-  // Toggle Why? off
-  const whyBtn = page.locator('#setting-why-btn');
-  await expect(whyBtn).toHaveText('On');
-  await whyBtn.click();
-  await expect(whyBtn).toHaveText('Off');
+  await settings.open();
+  await settings.expectWhyBtnOn();
+
+  await settings.toggleWhyBtn();
+  await settings.expectWhyBtnOff();
+  await settings.close();
 
   // Why? buttons on game cards should now be hidden
-  await page.locator('#settings-modal .modal-close').click();
-  await page.getByRole('button', { name: 'Find Games' }).click();
-  await expect(page.locator('.why-btn').first()).toBeHidden();
+  await main.findGames();
+  await expect(page.getByTestId('why-btn').first()).toBeHidden();
 });
 
 // ── History ────────────────────────────────────────────────────────────────
-test('history modal opens and shows empty state when no games played', async ({ page }) => {
-  await page.getByRole('button', { name: 'History' }).click();
-  await expect(page.locator('#history-modal')).toHaveClass(/active/);
-  // Either empty message or entries — just confirm modal rendered
-  await expect(page.locator('#history-list')).toBeVisible();
+test('history modal opens and list renders', async ({ page }) => {
+  const history = new HistoryModal(page);
+  await history.open();
+  await expect(history.list).toBeVisible();
 });
 
 // ── Stats ──────────────────────────────────────────────────────────────────
-test('stats modal opens with tab switcher', async ({ page }) => {
-  await page.getByRole('button', { name: 'Stats' }).click();
-  await expect(page.locator('#stats-modal')).toHaveClass(/active/);
-  await expect(page.locator('#tab-players')).toBeVisible();
-  await expect(page.locator('#tab-h2h')).toBeVisible();
+test('stats modal tab switcher works', async ({ page }) => {
+  const stats = new StatsModal(page);
+  await stats.open();
+  await expect(stats.tabPlayers).toBeVisible();
+  await expect(stats.tabH2H).toBeVisible();
 
-  await page.locator('#tab-h2h').click();
-  await expect(page.locator('#stats-body-h2h')).not.toHaveClass(/hidden/);
-  await expect(page.locator('#stats-body-players')).toHaveClass(/hidden/);
+  await stats.switchToH2H();
+  await stats.switchToPlayers();
 });

--- a/tests/pages/HistoryModal.js
+++ b/tests/pages/HistoryModal.js
@@ -1,0 +1,21 @@
+const { expect } = require('@playwright/test');
+
+class HistoryModal {
+  constructor(page) {
+    this.page  = page;
+    this.modal = page.getByTestId('history-modal');
+    this.list  = page.getByTestId('history-list');
+  }
+
+  async open() {
+    await this.page.getByTestId('btn-history').click();
+    await expect(this.modal).toHaveClass(/active/);
+  }
+
+  async close() {
+    await this.page.getByTestId('history-modal-close').click();
+    await expect(this.modal).not.toHaveClass(/active/);
+  }
+}
+
+module.exports = { HistoryModal };

--- a/tests/pages/LibraryModal.js
+++ b/tests/pages/LibraryModal.js
@@ -1,0 +1,75 @@
+const { expect } = require('@playwright/test');
+
+class LibraryModal {
+  constructor(page) {
+    this.page       = page;
+    this.modal      = page.getByTestId('library-modal');
+    this.searchInput = page.getByTestId('library-search');
+    this.count      = page.getByTestId('library-count');
+    this.list       = page.getByTestId('library-list');
+    this.addGameBtn = page.getByTestId('btn-add-game');
+    this.addForm    = page.getByTestId('add-game-form');
+
+    // Add game form fields
+    this.agName       = page.getByTestId('ag-name');
+    this.agMinPlayers = page.getByTestId('ag-min-players');
+    this.agMaxPlayers = page.getByTestId('ag-max-players');
+    this.agPlaytime   = page.getByTestId('ag-playtime');
+    this.agSubmit     = page.getByTestId('ag-submit');
+    this.agCancel     = page.getByTestId('ag-cancel');
+  }
+
+  async open() {
+    await this.page.getByTestId('btn-library').click();
+    await expect(this.modal).toHaveClass(/active/);
+  }
+
+  async close() {
+    await this.page.getByTestId('library-modal-close').click();
+    await expect(this.modal).not.toHaveClass(/active/);
+  }
+
+  async search(query) {
+    await this.searchInput.fill(query);
+  }
+
+  async sortBy(key) {
+    await this.page.getByTestId(`lib-sort-${key}`).click();
+  }
+
+  rows() {
+    return this.list.getByTestId('lib-row');
+  }
+
+  row(gameName) {
+    return this.list.getByTestId('lib-row').filter({ hasText: gameName });
+  }
+
+  async openAddForm() {
+    await this.addGameBtn.click();
+    await expect(this.addForm).not.toHaveClass(/hidden/);
+  }
+
+  async addGame({ name, minPlayers = '2', maxPlayers = '4', playtime = '60' } = {}) {
+    await this.openAddForm();
+    await this.agName.fill(name);
+    if (minPlayers) await this.agMinPlayers.fill(minPlayers);
+    if (maxPlayers) await this.agMaxPlayers.fill(maxPlayers);
+    if (playtime)   await this.agPlaytime.fill(playtime);
+    await this.agSubmit.click();
+  }
+
+  async deleteGame(gameName) {
+    await this.row(gameName).getByTestId('lib-delete').click();
+  }
+
+  async expectGame(gameName) {
+    await expect(this.row(gameName)).toBeVisible();
+  }
+
+  async expectNoGame(gameName) {
+    await expect(this.row(gameName)).toHaveCount(0);
+  }
+}
+
+module.exports = { LibraryModal };

--- a/tests/pages/MainPage.js
+++ b/tests/pages/MainPage.js
@@ -1,0 +1,107 @@
+const { expect } = require('@playwright/test');
+
+class MainPage {
+  constructor(page) {
+    this.page = page;
+
+    // Header nav buttons
+    this.btnSettings = page.getByTestId('btn-settings');
+    this.btnHistory  = page.getByTestId('btn-history');
+    this.btnStats    = page.getByTestId('btn-stats');
+    this.btnLibrary  = page.getByTestId('btn-library');
+    this.btnVault    = page.getByTestId('btn-vault');
+
+    // Roll call
+    this.rollCallChips = page.getByTestId('roll-call-chips');
+
+    // Quick search
+    this.searchInput   = page.getByTestId('search-input');
+    this.searchClearBtn = page.getByTestId('search-clear-btn');
+
+    // Filters
+    this.playersInput    = page.getByTestId('filter-players');
+    this.playtimeSelect  = page.getByTestId('filter-playtime');
+    this.complexitySelect = page.getByTestId('filter-complexity');
+    this.typeSelect      = page.getByTestId('filter-type');
+    this.ageSelect       = page.getByTestId('filter-age');
+    this.setupSelect     = page.getByTestId('filter-setup');
+    this.minRatingSelect = page.getByTestId('filter-min-rating');
+    this.newOnlyBtn      = page.getByTestId('new-only-btn');
+    this.coopBtn         = page.getByTestId('coop-btn');
+
+    // Action buttons
+    this.findGamesBtn = page.getByTestId('btn-find-games');
+    this.surpriseBtn  = page.getByTestId('btn-surprise');
+
+    // Results
+    this.results   = page.getByTestId('results');
+    this.noResults = page.getByTestId('no-results');
+    this.gameList  = page.getByTestId('game-list');
+  }
+
+  // ── Navigation ─────────────────────────────────────────────────────────────
+  async goto() {
+    await this.page.goto('/');
+    await this.page.waitForLoadState('networkidle');
+  }
+
+  // ── Roll Call ──────────────────────────────────────────────────────────────
+  rollCallChip(playerName) {
+    return this.rollCallChips.getByTestId('roll-call-chip').filter({ hasText: playerName });
+  }
+
+  async toggleRollCall(playerName) {
+    await this.rollCallChip(playerName).click();
+  }
+
+  // ── Filters ────────────────────────────────────────────────────────────────
+  async setPlayers(n) {
+    await this.playersInput.fill(String(n));
+  }
+
+  async setComplexity(value) {
+    await this.complexitySelect.selectOption(value);
+  }
+
+  async setType(value) {
+    await this.typeSelect.selectOption(value);
+  }
+
+  // ── Game list ──────────────────────────────────────────────────────────────
+  gameCards() {
+    return this.gameList.getByTestId('game-card');
+  }
+
+  async findGames() {
+    await this.findGamesBtn.click();
+  }
+
+  async surpriseMe() {
+    await this.surpriseBtn.click();
+  }
+
+  async search(query) {
+    await this.searchInput.fill(query);
+  }
+
+  async expandGameCard(index = 0) {
+    await this.gameCards().nth(index).click();
+  }
+
+  async letsPlay(index = 0) {
+    await this.expandGameCard(index);
+    await this.gameCards().nth(index).getByTestId('lets-play-btn').click();
+  }
+
+  // ── Assertions ─────────────────────────────────────────────────────────────
+  async expectResults() {
+    await expect(this.results).not.toHaveClass(/hidden/);
+    await expect(this.noResults).toHaveClass(/hidden/);
+  }
+
+  async expectNoResults() {
+    await expect(this.noResults).not.toHaveClass(/hidden/);
+  }
+}
+
+module.exports = { MainPage };

--- a/tests/pages/SessionModal.js
+++ b/tests/pages/SessionModal.js
@@ -1,0 +1,50 @@
+const { expect } = require('@playwright/test');
+
+class SessionModal {
+  constructor(page) {
+    this.page         = page;
+    this.modal        = page.getByTestId('session-modal');
+    this.title        = page.getByTestId('session-game-title');
+    this.timerDisplay = page.getByTestId('timer-display');
+    this.timerBtn     = page.getByTestId('timer-toggle-btn');
+    this.timerReset   = page.getByTestId('timer-reset-btn');
+    this.pauseBtn     = page.getByTestId('pause-btn');
+    this.endGameBtn   = page.getByTestId('end-game-btn');
+    this.finalizeBtn  = page.getByTestId('finalize-btn');
+    this.playerList   = page.getByTestId('session-player-list');
+    this.scoreList    = page.getByTestId('score-list');
+  }
+
+  async close() {
+    await this.page.getByTestId('session-modal-close').click();
+    await expect(this.modal).not.toHaveClass(/active/);
+  }
+
+  async startTimer() {
+    await this.timerBtn.click();
+    await expect(this.timerBtn).toHaveText('Pause');
+  }
+
+  async pauseTimer() {
+    await this.timerBtn.click();
+    await expect(this.timerBtn).toHaveText('Start');
+  }
+
+  async expectOpen() {
+    await expect(this.modal).toHaveClass(/active/);
+  }
+
+  async expectTitle(name) {
+    await expect(this.title).toHaveText(name);
+  }
+
+  async expectTimerRunning() {
+    await expect(this.timerBtn).toHaveText('Pause');
+  }
+
+  async expectTimerStopped() {
+    await expect(this.timerBtn).toHaveText('Start');
+  }
+}
+
+module.exports = { SessionModal };

--- a/tests/pages/SettingsModal.js
+++ b/tests/pages/SettingsModal.js
@@ -1,0 +1,34 @@
+const { expect } = require('@playwright/test');
+
+class SettingsModal {
+  constructor(page) {
+    this.page      = page;
+    this.modal     = page.getByTestId('settings-modal');
+    this.whyBtn    = page.getByTestId('setting-why-btn');
+    this.syncStatus = page.getByTestId('bgg-sync-status');
+  }
+
+  async open() {
+    await this.page.getByTestId('btn-settings').click();
+    await expect(this.modal).toHaveClass(/active/);
+  }
+
+  async close() {
+    await this.page.getByTestId('settings-modal-close').click();
+    await expect(this.modal).not.toHaveClass(/active/);
+  }
+
+  async toggleWhyBtn() {
+    await this.whyBtn.click();
+  }
+
+  async expectWhyBtnOn() {
+    await expect(this.whyBtn).toHaveText('On');
+  }
+
+  async expectWhyBtnOff() {
+    await expect(this.whyBtn).toHaveText('Off');
+  }
+}
+
+module.exports = { SettingsModal };

--- a/tests/pages/StatsModal.js
+++ b/tests/pages/StatsModal.js
@@ -1,0 +1,36 @@
+const { expect } = require('@playwright/test');
+
+class StatsModal {
+  constructor(page) {
+    this.page          = page;
+    this.modal         = page.getByTestId('stats-modal');
+    this.tabPlayers    = page.getByTestId('tab-players');
+    this.tabH2H        = page.getByTestId('tab-h2h');
+    this.bodyPlayers   = page.getByTestId('stats-body-players');
+    this.bodyH2H       = page.getByTestId('stats-body-h2h');
+  }
+
+  async open() {
+    await this.page.getByTestId('btn-stats').click();
+    await expect(this.modal).toHaveClass(/active/);
+  }
+
+  async close() {
+    await this.page.getByTestId('stats-modal-close').click();
+    await expect(this.modal).not.toHaveClass(/active/);
+  }
+
+  async switchToH2H() {
+    await this.tabH2H.click();
+    await expect(this.bodyH2H).not.toHaveClass(/hidden/);
+    await expect(this.bodyPlayers).toHaveClass(/hidden/);
+  }
+
+  async switchToPlayers() {
+    await this.tabPlayers.click();
+    await expect(this.bodyPlayers).not.toHaveClass(/hidden/);
+    await expect(this.bodyH2H).toHaveClass(/hidden/);
+  }
+}
+
+module.exports = { StatsModal };

--- a/tests/pages/VaultModal.js
+++ b/tests/pages/VaultModal.js
@@ -1,0 +1,44 @@
+const { expect } = require('@playwright/test');
+
+class VaultModal {
+  constructor(page) {
+    this.page      = page;
+    this.modal     = page.getByTestId('vault-modal');
+    this.nameInput = page.getByTestId('vault-name-input');
+    this.addBtn    = page.getByTestId('vault-add-btn');
+    this.list      = page.getByTestId('vault-list');
+  }
+
+  async open() {
+    await this.page.getByTestId('btn-vault').click();
+    await expect(this.modal).toHaveClass(/active/);
+  }
+
+  async close() {
+    await this.page.getByTestId('vault-modal-close').click();
+    await expect(this.modal).not.toHaveClass(/active/);
+  }
+
+  async addPlayer(name) {
+    await this.nameInput.fill(name);
+    await this.addBtn.click();
+  }
+
+  player(name) {
+    return this.list.getByTestId('vault-player').filter({ hasText: name });
+  }
+
+  async removePlayer(name) {
+    await this.player(name).getByTestId('vault-remove').click();
+  }
+
+  async expectPlayer(name) {
+    await expect(this.player(name)).toBeVisible();
+  }
+
+  async expectNoPlayer(name) {
+    await expect(this.player(name)).toHaveCount(0);
+  }
+}
+
+module.exports = { VaultModal };


### PR DESCRIPTION
## What changed

### data-testid attributes
Added `data-testid` to all testable elements so tests are decoupled from CSS class names and visible text that naturally change as the UI evolves:
- All static elements in `index.html` (buttons, inputs, modals, containers)
- Dynamic elements in `app.js`: game cards, vault player rows, roll call chips, library rows and delete buttons

### Page objects — `tests/pages/`
One class per UI surface, each encapsulating locators and exposing semantic interaction methods:

| File | Covers |
|---|---|
| `MainPage.js` | Filters, search, game list, roll call, nav buttons |
| `VaultModal.js` | Add/remove players, assertions |
| `SessionModal.js` | Timer, player list, score, finalize |
| `LibraryModal.js` | Search, sort, add/delete games |
| `SettingsModal.js` | Why? toggle, BGG import status |
| `HistoryModal.js` | Open/close, list |
| `StatsModal.js` | Tab switcher, player/H2H views |

### Spec file
`tests/app.spec.js` now reads as user flows rather than raw selectors:
```js
// Before
await page.getByRole('button', { name: 'Player Vault' }).click();
await page.fill('#vault-name-input', 'Alice');
await page.getByRole('button', { name: 'Add' }).click();
await expect(page.locator('#vault-list')).toContainText('Alice');

// After
const vault = new VaultModal(page);
await vault.open();
await vault.addPlayer('Alice');
await vault.expectPlayer('Alice');
```

19/19 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)