### PR TITLE
Add dice roller + BGG live sync

### DIFF
--- a/app.js
+++ b/app.js
@@ -229,10 +229,15 @@ function renderSettingsModal() {
     btn.classList.toggle('toggle-on', settings.showWhyBtn);
   }
 
+  const usernameInput = document.getElementById('bgg-username-input');
+  if (usernameInput && settings.bggUsername) {
+    usernameInput.value = settings.bggUsername;
+  }
+
   const statusEl = document.getElementById('bgg-sync-status');
   if (statusEl && settings.bggLastSync) {
     const count = JSON.parse(localStorage.getItem('sz-games') || '[]').length;
-    statusEl.textContent = `${count} games imported · ${settings.bggLastSync}`;
+    statusEl.textContent = `${count} games synced · ${settings.bggLastSync}`;
     statusEl.className = 'bgg-sync-status bgg-sync-ok';
   }
 }
@@ -359,6 +364,63 @@ function handleBGGImport(input) {
     statusEl.className = 'bgg-sync-status bgg-sync-error';
   };
   reader.readAsText(file);
+}
+
+async function syncBGGCollection() {
+  const input = document.getElementById('bgg-username-input');
+  const statusEl = document.getElementById('bgg-sync-status');
+  const btn = document.getElementById('bgg-sync-btn');
+  const username = input.value.trim();
+
+  if (!username) {
+    input.classList.add('input-error');
+    setTimeout(() => input.classList.remove('input-error'), 1200);
+    return;
+  }
+
+  // Save username for next time
+  settings.bggUsername = username;
+  localStorage.setItem('sz-settings', JSON.stringify(settings));
+
+  btn.disabled = true;
+  btn.textContent = 'Syncing…';
+  statusEl.textContent = 'Connecting to BoardGameGeek…';
+  statusEl.className = 'bgg-sync-status';
+
+  try {
+    const res = await fetch(`/api/bgg/collection?username=${encodeURIComponent(username)}`);
+    const data = await res.json();
+
+    if (!res.ok) {
+      statusEl.textContent = data.error || 'Sync failed.';
+      statusEl.className = 'bgg-sync-status bgg-sync-error';
+      return;
+    }
+
+    if (data.games.length === 0) {
+      statusEl.textContent = 'No owned games found on BGG for that username.';
+      statusEl.className = 'bgg-sync-status bgg-sync-error';
+      return;
+    }
+
+    games = data.games;
+    localStorage.setItem('sz-games', JSON.stringify(games));
+
+    settings.bggLastSync = new Date().toLocaleDateString('en-US', {
+      month: 'short', day: 'numeric', year: '2-digit',
+    });
+    localStorage.setItem('sz-settings', JSON.stringify(settings));
+
+    statusEl.textContent = `${data.count} games synced · ${settings.bggLastSync}`;
+    statusEl.className = 'bgg-sync-status bgg-sync-ok';
+    renderGames();
+  } catch (err) {
+    statusEl.textContent = 'Network error — is the server running?';
+    statusEl.className = 'bgg-sync-status bgg-sync-error';
+  } finally {
+    btn.disabled = false;
+    btn.textContent = 'Sync';
+  }
 }
 
 function toggleSetting(key) {
@@ -549,6 +611,7 @@ function openSession(index) {
   renderSessionPlayers();
   initScoreTracker();
   resetTimer();
+  resetDiceRoller();
   loadSpotifyPlaylist(sessionGame);
   document.getElementById('session-modal').classList.add('active');
 }
@@ -873,11 +936,15 @@ function saveResult(result) {
 function showSessionView() {
   document.getElementById('left-slider').classList.remove('show-feedback');
   document.getElementById('pause-btn').classList.remove('hidden');
+  const ds = document.getElementById('dice-section');
+  if (ds) ds.style.display = '';
 }
 
 function showFeedbackView() {
   document.getElementById('left-slider').classList.add('show-feedback');
   document.getElementById('pause-btn').classList.add('hidden');
+  const ds = document.getElementById('dice-section');
+  if (ds) ds.style.display = 'none';
 }
 
 function pauseSession() {
@@ -1656,6 +1723,113 @@ function renderTimerDisplay() {
   const s = timerSeconds % 60;
   const el = document.getElementById('timer-display');
   if (el) el.textContent = `${h}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+}
+
+// ── Dice Roller ────────────────────────────────────────────────────────────
+let selectedDieSides = 6;
+let diceHistory = [];
+let diceRolling = false;
+
+// Each entry: [cx, cy, r] — value 1 uses a larger pip so it reads clearly
+const D6_PIPS = {
+  1: [[32, 32, 7]],
+  2: [[18, 18, 5], [46, 46, 5]],
+  3: [[18, 18, 5], [32, 32, 5], [46, 46, 5]],
+  4: [[18, 18, 5], [46, 18, 5], [18, 46, 5], [46, 46, 5]],
+  5: [[18, 18, 5], [46, 18, 5], [32, 32, 5], [18, 46, 5], [46, 46, 5]],
+  6: [[18, 14, 5], [46, 14, 5], [18, 32, 5], [46, 32, 5], [18, 50, 5], [46, 50, 5]],
+};
+
+const DIE_CONFIG = {
+  4:  { path: 'M32,5 L61,59 L3,59 Z',                      tx: 32, ty: 47 },
+  8:  { path: 'M32,5 L59,32 L32,59 L5,32 Z',               tx: 32, ty: 35 },
+  10: { path: 'M32,5 L57,26 L48,59 L32,50 L16,59 L7,26 Z', tx: 32, ty: 36 },
+  12: { path: 'M32,5 L58,24 L49,56 L15,56 L6,24 Z',        tx: 32, ty: 38 },
+  20: { path: 'M32,5 L62,59 L2,59 Z',                      tx: 32, ty: 44 },
+};
+
+function renderDiceFace(sides, value, rolling) {
+  const svg = document.getElementById('dice-svg');
+  if (!svg) return;
+  const stroke = rolling ? '#2a3a5e' : '#f5c842';
+  const fill   = '#0f3460';
+  const ink    = rolling ? '#2a3a5e' : '#f5c842';
+
+  if (sides === 6) {
+    const pips = (value && D6_PIPS[value]) ? D6_PIPS[value] : [];
+    const dots = pips.map(([cx, cy, r]) =>
+      `<circle cx="${cx}" cy="${cy}" r="${r}" fill="${ink}"/>`
+    ).join('');
+    svg.innerHTML =
+      `<rect x="4" y="4" width="56" height="56" rx="10" fill="${fill}" stroke="${stroke}" stroke-width="2.5"/>` +
+      dots;
+  } else {
+    const cfg = DIE_CONFIG[sides];
+    if (!cfg) return;
+    const label = value != null ? String(value) : '';
+    const fs = sides === 20 && value >= 10 ? 16 : 18;
+    svg.innerHTML =
+      `<path d="${cfg.path}" fill="${fill}" stroke="${stroke}" stroke-width="2.5" stroke-linejoin="round"/>` +
+      `<text x="${cfg.tx}" y="${cfg.ty}" text-anchor="middle" dominant-baseline="middle"
+             fill="${ink}" font-size="${fs}" font-weight="700" font-family="inherit">${label}</text>`;
+  }
+}
+
+function selectDie(btn) {
+  document.querySelectorAll('.dice-die-btn').forEach(b => b.classList.remove('active'));
+  btn.classList.add('active');
+  selectedDieSides = parseInt(btn.dataset.sides);
+  renderDiceFace(selectedDieSides, null, false);
+}
+
+function rollDie() {
+  if (diceRolling) return;
+  diceRolling = true;
+  const finalResult = Math.floor(Math.random() * selectedDieSides) + 1;
+  const btn = document.querySelector('.dice-roll-btn');
+  const svg = document.getElementById('dice-svg');
+  btn.disabled = true;
+
+  svg.classList.remove('dice-shaking');
+  void svg.offsetWidth;
+  svg.classList.add('dice-shaking');
+
+  let cycles = 0;
+  const interval = setInterval(() => {
+    const rand = Math.floor(Math.random() * selectedDieSides) + 1;
+    renderDiceFace(selectedDieSides, rand, true);
+    cycles++;
+    if (cycles >= 8) {
+      clearInterval(interval);
+      renderDiceFace(selectedDieSides, finalResult, false);
+      btn.disabled = false;
+      diceRolling = false;
+
+      diceHistory.unshift({ sides: selectedDieSides, result: finalResult });
+      if (diceHistory.length > 5) diceHistory.pop();
+      renderDiceHistory();
+    }
+  }, 60);
+}
+
+function renderDiceHistory() {
+  const el = document.getElementById('dice-history');
+  if (!el) return;
+  el.innerHTML = diceHistory
+    .map(r => `<span class="dice-history-chip">d${r.sides}: <strong>${r.result}</strong></span>`)
+    .join('');
+}
+
+function resetDiceRoller() {
+  selectedDieSides = 6;
+  diceHistory = [];
+  diceRolling = false;
+  document.querySelectorAll('.dice-die-btn').forEach(b => {
+    b.classList.toggle('active', b.dataset.sides === '6');
+  });
+  renderDiceFace(6, null, false);
+  const histEl = document.getElementById('dice-history');
+  if (histEl) histEl.innerHTML = '';
 }
 
 // ── Quick Search ───────────────────────────────────────────────────────────

--- a/index.html
+++ b/index.html
@@ -244,6 +244,22 @@
               <p class="no-players-msg">Finding music…</p>
             </div>
           </div>
+          <div class="modal-section" id="dice-section">
+            <div class="modal-section-label">Dice Roller</div>
+            <div class="dice-die-row">
+              <button class="dice-die-btn active" data-testid="dice-btn-d6" data-sides="6" onclick="selectDie(this)">d6</button>
+              <button class="dice-die-btn" data-testid="dice-btn-d4"  data-sides="4"  onclick="selectDie(this)">d4</button>
+              <button class="dice-die-btn" data-testid="dice-btn-d8"  data-sides="8"  onclick="selectDie(this)">d8</button>
+              <button class="dice-die-btn" data-testid="dice-btn-d10" data-sides="10" onclick="selectDie(this)">d10</button>
+              <button class="dice-die-btn" data-testid="dice-btn-d12" data-sides="12" onclick="selectDie(this)">d12</button>
+              <button class="dice-die-btn" data-testid="dice-btn-d20" data-sides="20" onclick="selectDie(this)">d20</button>
+            </div>
+            <div class="dice-roll-row">
+              <svg id="dice-svg" data-testid="dice-svg" class="dice-svg" viewBox="0 0 64 64"></svg>
+              <button class="dice-roll-btn" data-testid="dice-roll-btn" onclick="rollDie()">Roll</button>
+            </div>
+            <div id="dice-history" data-testid="dice-history" class="dice-history"></div>
+          </div>
         </div>
       </div>
     </div>
@@ -269,13 +285,26 @@
         <div class="settings-group-label">BoardGameGeek</div>
         <div class="settings-row settings-row-column">
           <div class="settings-row-info">
-            <div class="settings-row-label">Import Collection (CSV)</div>
-            <div class="settings-row-desc">On BGG: go to your collection → Export → CSV. Import that file here.</div>
+            <div class="settings-row-label">Sync Collection</div>
+            <div class="settings-row-desc">Enter your BGG username to import your owned games.</div>
+          </div>
+          <div class="bgg-username-row">
+            <input type="text" id="bgg-username-input" data-testid="bgg-username-input"
+                   class="bgg-username-input" placeholder="BGG username"
+                   onkeydown="if(event.key==='Enter')syncBGGCollection()" />
+            <button id="bgg-sync-btn" data-testid="bgg-sync-btn"
+                    class="bgg-sync-btn" onclick="syncBGGCollection()">Sync</button>
+          </div>
+          <div id="bgg-sync-status" data-testid="bgg-sync-status" class="bgg-sync-status"></div>
+        </div>
+        <div class="settings-row settings-row-column">
+          <div class="settings-row-info">
+            <div class="settings-row-label">Import from CSV</div>
+            <div class="settings-row-desc">Alternatively: on BGG go to your collection → Export → CSV.</div>
           </div>
           <label class="bgg-file-label" for="bgg-csv-input">Choose CSV file</label>
           <input type="file" id="bgg-csv-input" data-testid="bgg-csv-input" accept=".csv"
                  class="bgg-file-input" onchange="handleBGGImport(this)" />
-          <div id="bgg-sync-status" data-testid="bgg-sync-status" class="bgg-sync-status"></div>
         </div>
 
         <div class="settings-group-label" style="margin-top:1rem">AI Features</div>

--- a/server.js
+++ b/server.js
@@ -156,12 +156,144 @@ function serveStatic(req, res) {
   });
 }
 
+// ── BGG Collection Sync ────────────────────────────────────────────────────
+function parseBGGXml(xml) {
+  const games = [];
+  const parts = xml.split("<item ");
+
+  for (let i = 1; i < parts.length; i++) {
+    const block = "<item " + parts[i];
+
+    const idMatch = block.match(/objectid="(\d+)"/);
+    if (!idMatch) continue;
+    const bggId = parseInt(idMatch[1]);
+
+    const subtypeMatch = block.match(/subtype="([^"]*)"/);
+    if (subtypeMatch && subtypeMatch[1] === "boardgameexpansion") continue;
+
+    const nameMatch = block.match(/<name[^>]*>([^<]*)<\/name>/);
+    if (!nameMatch) continue;
+    const name = nameMatch[1].trim();
+
+    const thumbMatch = block.match(/<thumbnail>\s*([^<\s]+)\s*<\/thumbnail>/);
+    const thumbnail = thumbMatch
+      ? thumbMatch[1].trim().replace(/^\/\//, "https://")
+      : null;
+
+    const statsMatch = block.match(/<stats\s([^>]*)>/);
+    let minPlayers = 1, maxPlayers = 4, minPlaytime = 0, maxPlaytime = 0;
+    if (statsMatch) {
+      const sa = statsMatch[1];
+      minPlayers  = parseInt(sa.match(/minplayers="(\d+)"/)?.[1])  || 1;
+      maxPlayers  = parseInt(sa.match(/maxplayers="(\d+)"/)?.[1])  || minPlayers;
+      minPlaytime = parseInt(sa.match(/minplaytime="(\d+)"/)?.[1]) || 0;
+      maxPlaytime = parseInt(sa.match(/maxplaytime="(\d+)"/)?.[1]) || 0;
+    }
+
+    const avgMatch = block.match(/<average\s+value="([^"]*)"/);
+    let rating = null;
+    if (avgMatch && avgMatch[1] !== "N/A") {
+      const raw = parseFloat(avgMatch[1]);
+      if (!isNaN(raw) && raw > 0) {
+        rating = Math.min(5, Math.max(1, Math.round(raw / 2)));
+      }
+    }
+
+    const playsMatch = block.match(/<numplays>(\d+)<\/numplays>/);
+    const played = playsMatch ? parseInt(playsMatch[1]) > 0 : false;
+
+    const playTime = maxPlaytime || minPlaytime || 60;
+
+    games.push({
+      name,
+      minPlayers,
+      maxPlayers,
+      playTime: playTime >= 999 ? 999 : playTime,
+      complexity: "Medium",
+      type: "Board",
+      age: 0,
+      setupTime: 10,
+      rating,
+      played,
+      cooperative: false,
+      thumbnail,
+      bggId,
+    });
+  }
+
+  return games.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+async function handleBGGCollection(req, res) {
+  const url = new URL(req.url, "http://localhost");
+  const username = url.searchParams.get("username")?.trim();
+  if (!username) {
+    res.writeHead(400, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "username required" }));
+    return;
+  }
+
+  const bggUrl =
+    `https://boardgamegeek.com/xmlapi2/collection` +
+    `?username=${encodeURIComponent(username)}&own=1` +
+    `&excludesubtype=boardgameexpansion&stats=1`;
+
+  const bggToken = process.env.BGG_API_TOKEN;
+  const headers = bggToken ? { Authorization: `Bearer ${bggToken}` } : {};
+
+  let xml = null;
+  for (let attempt = 0; attempt < 4; attempt++) {
+    if (attempt > 0) await new Promise((r) => setTimeout(r, 3000));
+    let bggRes;
+    try {
+      bggRes = await fetch(bggUrl, { headers });
+    } catch (err) {
+      res.writeHead(502, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Could not reach BoardGameGeek" }));
+      return;
+    }
+    if (bggRes.status === 202) continue; // BGG is building the response
+    if (bggRes.status === 401) {
+      res.writeHead(401, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "BGG API token missing or invalid. Add BGG_API_TOKEN to your .env file." }));
+      return;
+    }
+    if (bggRes.status === 404) {
+      res.writeHead(404, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: `BGG user "${username}" not found` }));
+      return;
+    }
+    if (!bggRes.ok) {
+      res.writeHead(bggRes.status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: `BGG returned ${bggRes.status}` }));
+      return;
+    }
+    xml = await bggRes.text();
+    break;
+  }
+
+  if (!xml) {
+    res.writeHead(503, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({
+      error: "BGG is still building your collection. Wait a moment and try again.",
+      retry: true,
+    }));
+    return;
+  }
+
+  const games = parseBGGXml(xml);
+  res.writeHead(200, { "Content-Type": "application/json" });
+  res.end(JSON.stringify({ games, count: games.length }));
+}
+
 const server = http.createServer((req, res) => {
   res.setHeader("Access-Control-Allow-Origin", "*");
   if (req.method === "POST" && req.url === "/api/why") {
     handleWhy(req, res);
   } else if (req.method === "GET" && req.url.startsWith("/api/spotify/playlist")) {
     handleSpotifyPlaylist(req, res);
+  } else if (req.method === "GET" && req.url.startsWith("/api/bgg/collection")) {
+    handleBGGCollection(req, res);
   } else {
     serveStatic(req, res);
   }

--- a/style.css
+++ b/style.css
@@ -907,6 +907,96 @@ button:hover {
   border: 1px solid #1a4a80;
 }
 
+/* ── Dice Roller ─────────────────────────────────────────────────────────── */
+.dice-die-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-bottom: 0.7rem;
+}
+
+.dice-die-btn {
+  padding: 0.3rem 0.55rem;
+  background: #0f3460;
+  color: #9a9ab0;
+  border: 1px solid #1a4a80;
+  border-radius: 6px;
+  font-size: 0.78rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.dice-die-btn:hover {
+  color: #e8eaf6;
+  border-color: #3a6aaa;
+}
+
+.dice-die-btn.active {
+  background: #1a4a80;
+  color: #f5c842;
+  border-color: #f5c842;
+}
+
+.dice-roll-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.6rem;
+}
+
+.dice-svg {
+  width: 60px;
+  height: 60px;
+  flex-shrink: 0;
+}
+
+@keyframes dice-shake {
+  0%   { transform: rotate(0deg)   scale(1); }
+  15%  { transform: rotate(-10deg) scale(1.12); }
+  35%  { transform: rotate(9deg)   scale(1.08); }
+  55%  { transform: rotate(-6deg)  scale(1.1); }
+  75%  { transform: rotate(4deg)   scale(1.05); }
+  100% { transform: rotate(0deg)   scale(1); }
+}
+
+.dice-shaking {
+  animation: dice-shake 0.5s ease-in-out;
+}
+
+.dice-roll-btn {
+  padding: 0.45rem 1rem;
+  background: #f5c842;
+  color: #1a1a2e;
+  border: none;
+  border-radius: 8px;
+  font-size: 0.88rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.dice-roll-btn:hover {
+  background: #ffd966;
+}
+
+.dice-history {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  min-height: 1.4rem;
+}
+
+.dice-history-chip {
+  font-size: 0.75rem;
+  color: #6a7a90;
+  background: #0f3460;
+  border-radius: 4px;
+  padding: 0.15rem 0.45rem;
+}
+
+.dice-history-chip strong {
+  color: #9a9ab0;
+}
+
 /* ── Score Tracker ───────────────────────────────────────────────────────── */
 .score-header {
   display: flex;
@@ -1925,6 +2015,53 @@ body.hide-why .why-btn {
   flex-direction: column;
   align-items: flex-start;
   gap: 0.5rem;
+}
+
+.bgg-username-row {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.bgg-username-input {
+  flex: 1;
+  padding: 0.5rem 0.75rem;
+  background: #1a1a2e;
+  border: 1px solid #2a3a5e;
+  border-radius: 8px;
+  color: #e8eaf6;
+  font-size: 0.88rem;
+  outline: none;
+}
+
+.bgg-username-input:focus {
+  border-color: #f5c842;
+}
+
+.bgg-username-input.input-error {
+  border-color: #e05252;
+  animation: shake 0.3s;
+}
+
+.bgg-sync-btn {
+  padding: 0.5rem 1rem;
+  background: #f5c842;
+  color: #1a1a2e;
+  border: none;
+  border-radius: 8px;
+  font-size: 0.88rem;
+  font-weight: 700;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.bgg-sync-btn:hover:not(:disabled) {
+  background: #ffd966;
+}
+
+.bgg-sync-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
 }
 
 .bgg-file-input {


### PR DESCRIPTION
## Summary
- Adds a Dice Roller panel to the session dashboard (d4/d6/d8/d10/d12/d20, SVG face, shake animation, last-5 history)
- Adds BGG live sync to Settings — username input, server proxy at `/api/bgg/collection`, XML parser, 202 retry logic
- Dice section hides automatically during the feedback view

## Notes
BGG sync code is complete but blocked on API token approval (issue #15). Will go live once `BGG_API_TOKEN` is added to `.env`.

Closes #27 · Refs #15, #55

## Test plan
- [ ] Open session → Dice Roller panel visible, all 6 die types roll correctly
- [ ] Roll history shows last 5 rolls
- [ ] Click "End Game" → dice panel hides; return to session → reappears
- [ ] New session → dice state resets to d6
- [ ] Settings → BGG username field persists across modal open/close
- [ ] Sync with invalid/empty username shows error state

🤖 Generated with [Claude Code](https://claude.com/claude-code)