### PR TITLE
Wire CI secrets into Playwright workflow

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -24,3 +24,17 @@ jobs:
 
       - name: Run Playwright tests
         run: npx playwright test
+        env:
+          # REQUIRED: the Anthropic SDK is instantiated at server startup (server.js line 7).
+          # The server will not start without this key, regardless of whether any test
+          # calls the /api/why endpoint.
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+
+          # OPTIONAL: only used when the /api/spotify/playlist endpoint is called.
+          # No current test triggers this route, so these can be omitted without
+          # breaking the test suite. Included here so CI mirrors the production environment.
+          SPOTIFY_CLIENT_ID: ${{ secrets.SPOTIFY_CLIENT_ID }}
+          SPOTIFY_CLIENT_SECRET: ${{ secrets.SPOTIFY_CLIENT_SECRET }}
+
+          # NOT REQUIRED: BGG_API_TOKEN is optional even in production (falls back to
+          # unauthenticated requests). Not included here.


### PR DESCRIPTION
## Summary

Updates `.github/workflows/playwright.yml` to pass the necessary secrets as environment variables to the server process.

**Audit findings — all 19 tests are pure UI and do not call any API routes directly.**

| Secret | Required for CI? | Reason |
|---|---|---|
| `ANTHROPIC_API_KEY` | Yes | Anthropic SDK is instantiated at server startup (`server.js:7`). Server throws and won't start without it. |
| `SPOTIFY_CLIENT_ID` | No (included anyway) | Only used inside `handleSpotifyPlaylist()`. No test hits `/api/spotify/playlist`, but included so CI mirrors production. |
| `SPOTIFY_CLIENT_SECRET` | No (included anyway) | Same as above. |
| `BGG_API_TOKEN` | No | Optional even in production — omitted from workflow. |

**Note:** actual secret values must be added manually in GitHub repo Settings > Secrets and variables > Actions before CI will pass.

## Test plan
- [ ] Secrets added to GitHub repo settings
- [ ] PR CI run completes without server startup failure
- [ ] All 19 tests pass

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)