### PR TITLE
Add Playwright test coverage for Spotify component

### DIFF
--- a/app.js
+++ b/app.js
@@ -657,7 +657,7 @@ function renderSpotifyOptions(container, options, selectedIdx, isSaved) {
     : '';
 
   container.innerHTML = `
-    <iframe id="spotify-iframe"
+    <iframe data-testid="spotify-iframe" id="spotify-iframe"
       src="${options[selectedIdx].embedUrl}"
       width="100%"
       height="152"
@@ -668,14 +668,14 @@ function renderSpotifyOptions(container, options, selectedIdx, isSaved) {
     ${optionsHtml}
     <div class="spotify-meta">
       <div class="spotify-actions">
-        <button class="spotify-change-btn" onclick="showSpotifySearch()">Change</button>
-        <button class="spotify-save-btn${isSaved ? ' saved' : ''}" onclick="saveSpotifyPlaylist()">
+        <button data-testid="spotify-change-btn" class="spotify-change-btn" onclick="showSpotifySearch()">Change</button>
+        <button data-testid="spotify-save-btn" class="spotify-save-btn${isSaved ? ' saved' : ''}" onclick="saveSpotifyPlaylist()">
           ${isSaved ? 'Saved ✓' : 'Save'}
         </button>
       </div>
     </div>
-    <div class="spotify-search-row hidden" id="spotify-search-row">
-      <input type="text" id="spotify-query-input" placeholder="Search Spotify…"
+    <div data-testid="spotify-search-row" class="spotify-search-row hidden" id="spotify-search-row">
+      <input data-testid="spotify-query-input" type="text" id="spotify-query-input" placeholder="Search Spotify…"
              onkeydown="if(event.key==='Enter') searchSpotifyQuery()" />
       <button onclick="searchSpotifyQuery()">Search</button>
     </div>
@@ -699,9 +699,9 @@ function selectSpotifyOption(idx) {
 
 function renderSpotifyNoResult(container) {
   container.innerHTML = `
-    <p class="no-players-msg">No playlist found — try a custom search.</p>
-    <div class="spotify-search-row" id="spotify-search-row">
-      <input type="text" id="spotify-query-input" placeholder="Search Spotify…"
+    <p data-testid="spotify-no-result" class="no-players-msg">No playlist found - try a custom search.</p>
+    <div data-testid="spotify-search-row" class="spotify-search-row" id="spotify-search-row">
+      <input data-testid="spotify-query-input" type="text" id="spotify-query-input" placeholder="Search Spotify…"
              onkeydown="if(event.key==='Enter') searchSpotifyQuery()" />
       <button onclick="searchSpotifyQuery()">Search</button>
     </div>

--- a/tests/app.spec.js
+++ b/tests/app.spec.js
@@ -6,6 +6,16 @@ const { LibraryModal } = require('./pages/LibraryModal');
 const { SettingsModal } = require('./pages/SettingsModal');
 const { HistoryModal } = require('./pages/HistoryModal');
 const { StatsModal }   = require('./pages/StatsModal');
+const { SpotifyPanel } = require('./pages/SpotifyPanel');
+
+// Mock Spotify API response used across Spotify tests.
+// Two playlists so we can also test the options row when needed.
+const MOCK_PLAYLISTS = {
+  playlists: [
+    { embedUrl: 'https://open.spotify.com/embed/playlist/MOCK001?utm_source=generator&theme=0', name: 'Mock Board Game Music' },
+    { embedUrl: 'https://open.spotify.com/embed/playlist/MOCK002?utm_source=generator&theme=0', name: 'Mock Chill Tunes' },
+  ],
+};
 
 // Each test gets a fresh localStorage so state doesn't bleed between runs.
 // waitForLoadState('networkidle') ensures games.json fetch completes first.
@@ -226,4 +236,126 @@ test('stats modal tab switcher works', async ({ page }) => {
 
   await stats.switchToH2H();
   await stats.switchToPlayers();
+});
+
+// ── Spotify ─────────────────────────────────────────────────────────────────
+// All Spotify tests mock /api/spotify/playlist at the network level using
+// page.route() — no live Spotify API calls are made during any test run.
+
+test('Spotify embed appears in session dashboard when a game is selected', async ({ page }) => {
+  await page.route('/api/spotify/playlist*', route =>
+    route.fulfill({ contentType: 'application/json', body: JSON.stringify(MOCK_PLAYLISTS) })
+  );
+
+  const main    = new MainPage(page);
+  const spotify = new SpotifyPanel(page);
+
+  await main.findGames();
+  await main.letsPlay(0);
+
+  await spotify.waitForEmbed();
+  await expect(spotify.iframe).toHaveAttribute('src', /open\.spotify\.com\/embed/);
+});
+
+test('auto-search sends game name and type as query params, not a manual query', async ({ page }) => {
+  const requestPromise = page.waitForRequest(/\/api\/spotify\/playlist/);
+
+  await page.route('/api/spotify/playlist*', route =>
+    route.fulfill({ contentType: 'application/json', body: JSON.stringify(MOCK_PLAYLISTS) })
+  );
+
+  const main = new MainPage(page);
+  await main.findGames();
+  await main.letsPlay(0);
+
+  const request = await requestPromise;
+  const url     = new URL(request.url());
+
+  expect(url.searchParams.get('game')).toBeTruthy();
+  expect(url.searchParams.get('type')).toBeTruthy();
+  expect(url.searchParams.has('query')).toBe(false);
+});
+
+test('manual search override updates the embed and sends query param', async ({ page }) => {
+  await page.route('/api/spotify/playlist*', (route, request) => {
+    const url = new URL(request.url());
+    if (url.searchParams.has('query')) {
+      route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          playlists: [{ embedUrl: 'https://open.spotify.com/embed/playlist/OVERRIDE?utm_source=generator&theme=0', name: 'Custom Result' }],
+        }),
+      });
+    } else {
+      route.fulfill({ contentType: 'application/json', body: JSON.stringify(MOCK_PLAYLISTS) });
+    }
+  });
+
+  const main    = new MainPage(page);
+  const spotify = new SpotifyPanel(page);
+
+  await main.findGames();
+  await main.letsPlay(0);
+  await spotify.waitForEmbed();
+
+  await spotify.openSearch();
+
+  const overrideRequest = page.waitForRequest(req => req.url().includes('/api/spotify/playlist') && req.url().includes('query='));
+  await spotify.searchFor('catan ambient');
+
+  const req = await overrideRequest;
+  const url = new URL(req.url());
+  expect(url.searchParams.get('query')).toBe('catan ambient');
+
+  await expect(spotify.iframe).toHaveAttribute('src', /OVERRIDE/);
+});
+
+test('saved playlist is restored on session resume without a new API call', async ({ page }) => {
+  let callCount = 0;
+  await page.route('/api/spotify/playlist*', route => {
+    callCount++;
+    route.fulfill({ contentType: 'application/json', body: JSON.stringify(MOCK_PLAYLISTS) });
+  });
+
+  const main    = new MainPage(page);
+  const session = new SessionModal(page);
+  const spotify = new SpotifyPanel(page);
+
+  await main.findGames();
+  await main.letsPlay(0);
+  await spotify.waitForEmbed();
+  expect(callCount).toBe(1);
+
+  await spotify.save();
+  await expect(spotify.saveBtn).toHaveClass(/saved/);
+
+  // Pause the session
+  await session.pauseBtn.click();
+  await expect(session.modal).not.toHaveClass(/active/);
+
+  // Resume via Games in Progress
+  const resumeBtn = page.locator('.resume-btn').first();
+  await expect(resumeBtn).toBeVisible();
+  await resumeBtn.click();
+
+  // Embed should reload from saved URL — no new API call
+  await spotify.waitForEmbed();
+  expect(callCount).toBe(1);
+  await expect(spotify.saveBtn).toHaveClass(/saved/);
+});
+
+test('shows no-result message and search input when Spotify returns no playlists', async ({ page }) => {
+  await page.route('/api/spotify/playlist*', route =>
+    route.fulfill({ status: 404, contentType: 'application/json', body: JSON.stringify({ error: 'No playlist found' }) })
+  );
+
+  const main    = new MainPage(page);
+  const spotify = new SpotifyPanel(page);
+
+  await main.findGames();
+  await main.letsPlay(0);
+
+  await expect(spotify.noResult).toBeVisible();
+  await expect(spotify.searchRow).toBeVisible();
+  await expect(spotify.iframe).not.toBeAttached();
 });

--- a/tests/pages/SpotifyPanel.js
+++ b/tests/pages/SpotifyPanel.js
@@ -1,0 +1,35 @@
+const { expect } = require('@playwright/test');
+
+class SpotifyPanel {
+  constructor(page) {
+    this.page       = page;
+    this.container  = page.getByTestId('spotify-container');
+    this.iframe     = page.getByTestId('spotify-iframe');
+    this.saveBtn    = page.getByTestId('spotify-save-btn');
+    this.changeBtn  = page.getByTestId('spotify-change-btn');
+    this.searchRow  = page.getByTestId('spotify-search-row');
+    this.queryInput = page.getByTestId('spotify-query-input');
+    this.noResult   = page.getByTestId('spotify-no-result');
+  }
+
+  async waitForEmbed() {
+    await expect(this.iframe).toBeVisible({ timeout: 5000 });
+  }
+
+  async save() {
+    await this.saveBtn.click();
+    await expect(this.saveBtn).toHaveClass(/saved/);
+  }
+
+  async openSearch() {
+    await this.changeBtn.click();
+    await expect(this.searchRow).not.toHaveClass(/hidden/);
+  }
+
+  async searchFor(query) {
+    await this.queryInput.fill(query);
+    await this.queryInput.press('Enter');
+  }
+}
+
+module.exports = { SpotifyPanel };


### PR DESCRIPTION
## Summary

Adds 5 Playwright tests covering the Spotify music player component. No live Spotify API calls are made — all tests mock `/api/spotify/playlist` at the network level using `page.route()`.

**New: `tests/pages/SpotifyPanel.js`** — page object for the Spotify panel with selectors for the embed, save, change, search row, query input, and no-result message.

**`data-testid` attributes added** to dynamically-rendered Spotify elements in `renderSpotifyOptions` and `renderSpotifyNoResult` in `app.js` so the POM can target them reliably.

## Tests added

| Test | What it validates |
|---|---|
| Embed appears on game selection | iframe is visible and src points to Spotify embed URL |
| Auto-search query params | `game` and `type` params sent, no `query` param |
| Manual override | `query` param sent, iframe src updates to new playlist |
| Save and restore on resume | No new API call on resume; save button shows saved state |
| No-result / error state | No-result message and search input visible; no iframe |

Suite grows from 19 to 24 tests.

## Test plan
- [ ] `npx playwright test` — all 24 pass locally
- [ ] No network requests to `api.spotify.com` or `accounts.spotify.com` during test run

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)