### PR TITLE
Add CLAUDE.md - Gloom's permanent memory file

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,6 @@
-# Session Zero - CLAUDE.md
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 ## Project Overview
 Session Zero is a vanilla HTML/CSS/JS + Node.js game night planning web app. Players filter a board game library by various criteria and get AI-powered recommendations. Built as a portfolio project demonstrating full-stack development, AI integration, and engineering workflow practices.
@@ -12,6 +14,63 @@ Session Zero is a vanilla HTML/CSS/JS + Node.js game night planning web app. Pla
 - CI/CD: GitHub Actions
 - Version control: Git + GitHub
 - Data: games.json (local), migrating to BoardGameGeek API
+
+## Commands
+
+Start the dev server:
+```bash
+node server.js
+```
+
+Run the full test suite (starts server automatically via webServer config):
+```bash
+npx playwright test
+```
+
+Run a single test by name:
+```bash
+npx playwright test --grep "test name here"
+```
+
+Run tests with the interactive UI:
+```bash
+npx playwright test --ui
+```
+
+## Architecture
+
+### No build step
+There is no bundler, transpiler, or framework. `index.html` is served directly. `app.js` and `style.css` are loaded as-is. Changes take effect on browser reload.
+
+### Server (server.js)
+Three API routes, everything else is static file serving:
+- `POST /api/why` - sends game + filter context to Claude API, streams back a recommendation explanation
+- `GET /api/spotify/playlist?game=&type=` or `?query=` - fetches a playlist from Spotify and returns up to 5 results as `{ playlists: [{ embedUrl, name }] }`
+- `GET /api/bgg/collection?username=` - proxies BoardGameGeek XML API, parses it, returns normalized game objects (blocked on BGG API token)
+
+### Frontend (app.js)
+Single 1800-line file organized into sections marked with `// ── Section Name ──` comments. Sections map directly to features: Player Vault, Roll Call, Settings, Filters, Game Cards, Why?, Session Modal, Spotify, Score Tracker, Timer, Dice Roller, Play History, Player Stats, Game Library, Quick Search.
+
+All state is module-level `let` variables at the top of the file. No state management library.
+
+### Data / localStorage
+All persistence is localStorage. Keys:
+- `sz-games` - game library array (overrides games.json if present)
+- `sz-vault` - permanent player registry
+- `sz-settings` - user preferences (showWhyBtn, bggUsername, bggLastSync)
+- `sz-history` - finalized session results
+- `sz-active-sessions` - paused (in-progress) sessions
+
+On startup, `sz-games` is loaded from localStorage if present, otherwise fetched from `games.json`.
+
+### Modal pattern
+Every modal is a `<div>` with a unique `data-testid`. Active state is toggled via `.classList.add('active')`. Session Dashboard is the main complex modal - it contains Score Tracker, Timer, Dice Roller, and Spotify panels as sub-sections within a left/right split layout.
+
+### Session lifecycle
+`openSession(index)` sets the global `sessionGame` and `sessionPlayers`, then initializes all sub-components (score tracker, timer, dice, Spotify). `pauseSession()` serializes full state to `sz-active-sessions`. `resumeSession(id)` restores it. `finalizeSession()` writes to `sz-history` and clears the active session.
+
+### Tests (tests/)
+All tests live in `tests/app.spec.js`. Page objects live in `tests/pages/`. Each page object maps to one modal or page area. `beforeEach` clears localStorage and reloads so tests are fully isolated. The `playwright.config.js` `webServer` block starts `node server.js` automatically - no manual server startup needed for tests.
 
 ## Conventions
 - Branch names: feature/short-description or fix/short-description


### PR DESCRIPTION
## Summary

Adds `CLAUDE.md` to the project root. Claude Code reads this file automatically at the start of every session, giving Gloom persistent memory of project conventions without needing to re-derive them from the codebase each time.

Covers:
- Project overview and tech stack
- Branch, commit, and PR conventions
- Test conventions (POM pattern, API mocking with page.route())
- No-em-dash rule
- Files never to touch (.env, package-lock.json, games.json, .github/workflows/)
- Working approach (plan before architectural work, tests before PR, focused scope)

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)