### PR TITLE
Document Playwright CI as required status check (branch protection)

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,4 +1,7 @@
 name: Playwright Tests
+# This workflow is configured as a required status check in GitHub branch protection settings
+# (Settings > Branches > main). PRs targeting main cannot be merged until this job passes.
+# To update the required check, go to Settings > Branches and edit the protection rule for main.
 
 on:
   pull_request:

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ git commit -m "Add dice roller to session dashboard"
 ### 7. Review and Merge
 - Diff is reviewed before merging, even on a solo project
 - GitHub Actions runs the full Playwright suite automatically on every PR
+- Branch protection on `main` requires the Playwright CI check to pass before merging - PRs are blocked until CI is green
 - Merges into `main` only after review and CI pass
 
 ### 8. Issue Closes Automatically


### PR DESCRIPTION
## Summary
- Adds a comment to `.github/workflows/playwright.yml` noting it is configured as a required status check in GitHub branch protection settings, with instructions for where to update the rule if needed
- Updates README Dev Workflow step 7 to explicitly state that branch protection on `main` blocks merges until the Playwright CI check passes

## Notes
The actual branch protection rule in GitHub Settings must be configured manually by Paul after this PR merges. Instructions from the issue:
- Settings > Branches > Add branch protection rule
- Branch name pattern: `main`
- Enable: Require status checks to pass before merging (select "Playwright Tests")
- Enable: Require branches to be up to date before merging
- Leave "Do not allow bypassing" unchecked

## Test plan
- [x] Verify `.github/workflows/playwright.yml` comment is accurate and links to the right settings location
- [x] Verify README step 7 clearly communicates the CI gate

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)