### PR TITLE
Fix Railway crash: set package.json main to server.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,9 @@
   "name": "session-zero",
   "version": "1.0.0",
   "description": "So many games, so little night.",
-  "main": "app.js",
+  "main": "server.js",
   "scripts": {
+    "start": "node server.js",
     "test": "playwright test",
     "test:ui": "playwright test --ui"
   },


### PR DESCRIPTION
## Problem
`package.json` had `"main": "app.js"`. Railway uses the `main` field to determine what to execute, so it was running the browser frontend file as the server, crashing immediately:

```
ReferenceError: localStorage is not defined at app.js:10:24
```

## Fix
- `"main": "app.js"` -> `"main": "server.js"`
- Added `"start": "node server.js"` so `npm start` works as Railway's default start command

## Test plan
- [x] `node server.js` starts cleanly on port 3000 locally
- [x] CI passes

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)