### PR TITLE
Fix Railway 'Cannot GET /': parse URL pathname before routing and file lookup

### DIFF
--- a/server.js
+++ b/server.js
@@ -140,9 +140,10 @@ Be enthusiastic and specific. Mention one standout feature of the game. If it's 
 }
 
 function serveStatic(req, res) {
+  const pathname = new URL(req.url, "http://localhost").pathname;
   const filePath = path.join(
     __dirname,
-    req.url === "/" ? "index.html" : req.url
+    pathname === "/" ? "index.html" : pathname
   );
   const ext = path.extname(filePath);
   fs.readFile(filePath, (err, data) => {
@@ -288,11 +289,12 @@ async function handleBGGCollection(req, res) {
 
 const server = http.createServer((req, res) => {
   res.setHeader("Access-Control-Allow-Origin", "*");
-  if (req.method === "POST" && req.url === "/api/why") {
+  const pathname = new URL(req.url, "http://localhost").pathname;
+  if (req.method === "POST" && pathname === "/api/why") {
     handleWhy(req, res);
-  } else if (req.method === "GET" && req.url.startsWith("/api/spotify/playlist")) {
+  } else if (req.method === "GET" && pathname.startsWith("/api/spotify/playlist")) {
     handleSpotifyPlaylist(req, res);
-  } else if (req.method === "GET" && req.url.startsWith("/api/bgg/collection")) {
+  } else if (req.method === "GET" && pathname.startsWith("/api/bgg/collection")) {
     handleBGGCollection(req, res);
   } else {
     serveStatic(req, res);


### PR DESCRIPTION
## Problem
`req.url` includes query strings. Using it raw caused two bugs:

1. `req.url === "/"` fails when any query string is present - `index.html` is never found
2. `path.join(__dirname, req.url)` with a query string builds an invalid file path

Railway's reverse proxy or health checks append query parameters, triggering "Cannot GET /" at the root.

## Fix
Parse `req.url` with `new URL(req.url, "http://localhost").pathname` to strip query strings before any routing comparison or `path.join` call. Applied in both the request router and `serveStatic`.

## Test plan
- [x] `curl http://localhost:3000` returns `index.html` locally
- [x] `curl http://localhost:3000/` returns `index.html` locally
- [x] CI passes

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)