### PR TITLE
Add database connection and schema

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -1,0 +1,14 @@
+const { Pool } = require("pg");
+
+let pool = null;
+
+if (!process.env.DATABASE_URL) {
+  console.warn("[DB] DATABASE_URL not set - database features disabled");
+} else {
+  pool = new Pool({
+    connectionString: process.env.DATABASE_URL,
+    ssl: { rejectUnauthorized: false },
+  });
+}
+
+module.exports = pool;

--- a/db/migrate.js
+++ b/db/migrate.js
@@ -1,0 +1,19 @@
+const fs = require("fs");
+const path = require("path");
+const pool = require("./index");
+
+async function migrate() {
+  if (!pool) {
+    console.log("[DB] Skipping migration - no database connection");
+    return;
+  }
+  const sql = fs.readFileSync(path.join(__dirname, "schema.sql"), "utf8");
+  try {
+    await pool.query(sql);
+    console.log("[DB] Schema migration complete");
+  } catch (err) {
+    console.error("[DB] Migration failed:", err.message);
+  }
+}
+
+module.exports = migrate;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS users (
+  id SERIAL PRIMARY KEY,
+  google_id TEXT UNIQUE NOT NULL,
+  email TEXT UNIQUE NOT NULL,
+  display_name TEXT,
+  avatar_url TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS session (
+  sid VARCHAR NOT NULL PRIMARY KEY,
+  sess JSON NOT NULL,
+  expire TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS session_expire_idx ON session (expire);

--- a/server.js
+++ b/server.js
@@ -14,6 +14,9 @@ app.use(require("./routes/auth"));
 app.use(require("./routes/api"));
 app.use(require("./routes/static"));
 
+const migrate = require("./db/migrate");
+migrate();
+
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {
   console.log(`Game Night Planner running at http://localhost:${PORT}`);


### PR DESCRIPTION
## Summary
- Adds `pg` connection pool, schema definition, and startup migration
- No auth wiring - just connection and schema as specified in #91

## New files
| File | Purpose |
|---|---|
| `db/schema.sql` | `users` and `session` table definitions, used by Passport and connect-pg-simple in #92-#93 |
| `db/index.js` | Exports a `pg.Pool` when `DATABASE_URL` is set, `null` otherwise - callers guard with `if (!pool)` |
| `db/migrate.js` | Runs `schema.sql` on startup via `pool.query()`, logs success or failure, never rethrows |

## server.js change
```js
const migrate = require("./db/migrate");
migrate();
```
Called before `app.listen()`, not awaited - server starts regardless of DB state.

## Startup behavior
**No `DATABASE_URL`:**
```
[DB] DATABASE_URL not set - database features disabled
[DB] Skipping migration - no database connection
```
**`DATABASE_URL` set, DB reachable:**
```
[DB] Schema migration complete
```
**`DATABASE_URL` set, DB unreachable (e.g. local dev pointing at Railway internal host):**
```
[DB] Migration failed: getaddrinfo ENOTFOUND postgres.railway.internal
```
Server starts cleanly in all three cases.

## Test plan
- [x] All 29 Playwright tests pass
- [x] Server starts cleanly with `DATABASE_URL` pointing to unreachable Railway host (graceful failure log, no crash)

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)