### PR TITLE
Implement Google OAuth with Passport

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -41,3 +41,18 @@ jobs:
 
           # NOT REQUIRED: BGG_API_TOKEN is optional even in production (falls back to
           # unauthenticated requests). Not included here.
+
+# CI environment variables
+# ANTHROPIC_API_KEY: required - server will not start without it
+# SPOTIFY_CLIENT_ID: included to mirror production environment
+# SPOTIFY_CLIENT_SECRET: included to mirror production environment
+#
+# Intentionally excluded from CI:
+# GOOGLE_CLIENT_ID: OAuth credentials not needed for automated tests
+# GOOGLE_CLIENT_SECRET: Auth routes are tested manually, not in Playwright
+# SESSION_SECRET: No session-dependent tests in the current suite
+# DATABASE_URL: No database-dependent tests in the current suite
+# APP_URL: Not needed without OAuth
+#
+# When auth route testing is added in the future, these will need
+# to be added as GitHub Actions secrets.

--- a/config/passport.js
+++ b/config/passport.js
@@ -1,0 +1,59 @@
+const passport = require("passport");
+const { Strategy: GoogleStrategy } = require("passport-google-oauth20");
+const pool = require("../db/index");
+
+passport.serializeUser((user, done) => {
+  done(null, user.id);
+});
+
+passport.deserializeUser(async (id, done) => {
+  if (!pool) return done(null, false);
+  try {
+    const result = await pool.query("SELECT * FROM users WHERE id = $1", [id]);
+    done(null, result.rows[0] || false);
+  } catch (err) {
+    done(err);
+  }
+});
+
+const callbackURL = `${process.env.APP_URL || "http://localhost:3000"}/auth/google/callback`;
+
+passport.use(
+  new GoogleStrategy(
+    {
+      clientID:     process.env.GOOGLE_CLIENT_ID,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+      callbackURL,
+    },
+    async (accessToken, refreshToken, profile, done) => {
+      if (!pool) {
+        console.error("[Auth] Cannot authenticate - database not configured");
+        return done(null, false);
+      }
+      try {
+        const existing = await pool.query(
+          "SELECT * FROM users WHERE google_id = $1",
+          [profile.id]
+        );
+        if (existing.rows.length > 0) return done(null, existing.rows[0]);
+
+        const inserted = await pool.query(
+          `INSERT INTO users (google_id, email, display_name, avatar_url)
+           VALUES ($1, $2, $3, $4) RETURNING *`,
+          [
+            profile.id,
+            profile.emails[0].value,
+            profile.displayName,
+            profile.photos[0]?.value ?? null,
+          ]
+        );
+        done(null, inserted.rows[0]);
+      } catch (err) {
+        console.error("[Auth] Database error during authentication:", err.message);
+        done(null, false);
+      }
+    }
+  )
+);
+
+module.exports = passport;

--- a/config/passport.js
+++ b/config/passport.js
@@ -16,44 +16,48 @@ passport.deserializeUser(async (id, done) => {
   }
 });
 
-const callbackURL = `${process.env.APP_URL || "http://localhost:3000"}/auth/google/callback`;
+if (process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET) {
+  const callbackURL = `${process.env.APP_URL || "http://localhost:3000"}/auth/google/callback`;
 
-passport.use(
-  new GoogleStrategy(
-    {
-      clientID:     process.env.GOOGLE_CLIENT_ID,
-      clientSecret: process.env.GOOGLE_CLIENT_SECRET,
-      callbackURL,
-    },
-    async (accessToken, refreshToken, profile, done) => {
-      if (!pool) {
-        console.error("[Auth] Cannot authenticate - database not configured");
-        return done(null, false);
-      }
-      try {
-        const existing = await pool.query(
-          "SELECT * FROM users WHERE google_id = $1",
-          [profile.id]
-        );
-        if (existing.rows.length > 0) return done(null, existing.rows[0]);
+  passport.use(
+    new GoogleStrategy(
+      {
+        clientID:     process.env.GOOGLE_CLIENT_ID,
+        clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+        callbackURL,
+      },
+      async (accessToken, refreshToken, profile, done) => {
+        if (!pool) {
+          console.error("[Auth] Cannot authenticate - database not configured");
+          return done(null, false);
+        }
+        try {
+          const existing = await pool.query(
+            "SELECT * FROM users WHERE google_id = $1",
+            [profile.id]
+          );
+          if (existing.rows.length > 0) return done(null, existing.rows[0]);
 
-        const inserted = await pool.query(
-          `INSERT INTO users (google_id, email, display_name, avatar_url)
-           VALUES ($1, $2, $3, $4) RETURNING *`,
-          [
-            profile.id,
-            profile.emails[0].value,
-            profile.displayName,
-            profile.photos[0]?.value ?? null,
-          ]
-        );
-        done(null, inserted.rows[0]);
-      } catch (err) {
-        console.error("[Auth] Database error during authentication:", err.message);
-        done(null, false);
+          const inserted = await pool.query(
+            `INSERT INTO users (google_id, email, display_name, avatar_url)
+             VALUES ($1, $2, $3, $4) RETURNING *`,
+            [
+              profile.id,
+              profile.emails[0].value,
+              profile.displayName,
+              profile.photos[0]?.value ?? null,
+            ]
+          );
+          done(null, inserted.rows[0]);
+        } catch (err) {
+          console.error("[Auth] Database error during authentication:", err.message);
+          done(null, false);
+        }
       }
-    }
-  )
-);
+    )
+  );
+} else {
+  console.warn("[Auth] GOOGLE_CLIENT_ID or GOOGLE_CLIENT_SECRET not set - OAuth disabled");
+}
 
 module.exports = passport;

--- a/login.html
+++ b/login.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Session Zero</title>
+  <link rel="stylesheet" href="/style.css" />
+  <style>
+    body {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+      padding: 2rem 1rem;
+    }
+
+    .login-card {
+      background: #16213e;
+      border: 1px solid #0f3460;
+      border-radius: 16px;
+      padding: 3rem 2.5rem;
+      text-align: center;
+      width: 100%;
+      max-width: 380px;
+    }
+
+    .login-card h1 {
+      font-size: 2rem;
+      color: #f5c842;
+      margin-bottom: 0.5rem;
+    }
+
+    .login-card .tagline {
+      color: #9a9ab0;
+      font-size: 0.95rem;
+      margin-bottom: 2.5rem;
+      font-style: italic;
+    }
+
+    .google-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.75rem;
+      background: #ffffff;
+      color: #1a1a2e;
+      border: none;
+      border-radius: 8px;
+      padding: 0.75rem 1.5rem;
+      font-size: 0.95rem;
+      font-weight: 600;
+      font-family: inherit;
+      text-decoration: none;
+      cursor: pointer;
+      transition: opacity 0.15s;
+    }
+
+    .google-btn:hover {
+      opacity: 0.9;
+    }
+
+    .google-btn svg {
+      flex-shrink: 0;
+    }
+  </style>
+</head>
+<body>
+  <div class="login-card">
+    <h1>Session Zero</h1>
+    <p class="tagline">So many games, so little night.</p>
+    <a href="/auth/google" class="google-btn">
+      <svg width="18" height="18" viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg">
+        <path d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844c-.209 1.125-.843 2.078-1.796 2.716v2.259h2.908c1.702-1.567 2.684-3.875 2.684-6.615z" fill="#4285F4"/>
+        <path d="M9 18c2.43 0 4.467-.806 5.956-2.184l-2.908-2.259c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332A8.997 8.997 0 0 0 9 18z" fill="#34A853"/>
+        <path d="M3.964 10.706A5.41 5.41 0 0 1 3.682 9c0-.593.102-1.17.282-1.706V4.962H.957A8.996 8.996 0 0 0 0 9c0 1.452.348 2.827.957 4.038l3.007-2.332z" fill="#FBBC05"/>
+        <path d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 0 0 .957 4.962L3.964 7.294C4.672 5.163 6.656 3.58 9 3.58z" fill="#EA4335"/>
+      </svg>
+      Sign in with Google
+    </a>
+  </div>
+</body>
+</html>

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -1,8 +1,33 @@
 const express = require("express");
+const path = require("path");
+const passport = require("../config/passport");
+const pool = require("../db/index");
 
 const router = express.Router();
 
-// Auth routes will be added in issue #92 (Google OAuth with Passport).
-// This file is a placeholder to establish the module structure.
+router.get("/login", (req, res) => {
+  res.sendFile(path.join(__dirname, "../login.html"));
+});
+
+router.get("/auth/google", (req, res, next) => {
+  if (!pool) {
+    return res.status(503).json({ error: "Database not configured - set DATABASE_URL to enable authentication" });
+  }
+  passport.authenticate("google", { scope: ["profile", "email"] })(req, res, next);
+});
+
+router.get(
+  "/auth/google/callback",
+  passport.authenticate("google", { failureRedirect: "/login" }),
+  (req, res) => {
+    res.redirect("/");
+  }
+);
+
+router.get("/auth/logout", (req, res) => {
+  req.logout(() => {
+    res.redirect("/login");
+  });
+});
 
 module.exports = router;

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -13,6 +13,9 @@ router.get("/auth/google", (req, res, next) => {
   if (!pool) {
     return res.status(503).json({ error: "Database not configured - set DATABASE_URL to enable authentication" });
   }
+  if (!process.env.GOOGLE_CLIENT_ID) {
+    return res.status(503).json({ error: "OAuth not configured" });
+  }
   passport.authenticate("google", { scope: ["profile", "email"] })(req, res, next);
 });
 

--- a/server.js
+++ b/server.js
@@ -1,5 +1,8 @@
 require("dotenv").config();
 const express = require("express");
+const session = require("express-session");
+const passport = require("./config/passport");
+const pool = require("./db/index");
 
 const app = express();
 
@@ -10,12 +13,33 @@ app.use((req, res, next) => {
 
 app.use(express.json());
 
+const migrate = require("./db/migrate");
+migrate();
+
+const sessionStore = pool
+  ? new (require("connect-pg-simple")(session))({
+      pool,
+      tableName: "session",
+      createTableIfMissing: false,
+    })
+  : undefined;
+
+app.use(
+  session({
+    store: sessionStore,
+    secret: process.env.SESSION_SECRET || "dev-secret-change-in-production",
+    resave: false,
+    saveUninitialized: false,
+    cookie: { maxAge: 30 * 24 * 60 * 60 * 1000 },
+  })
+);
+
+app.use(passport.initialize());
+app.use(passport.session());
+
 app.use(require("./routes/auth"));
 app.use(require("./routes/api"));
 app.use(require("./routes/static"));
-
-const migrate = require("./db/migrate");
-migrate();
 
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {


### PR DESCRIPTION
## Summary
- Google OAuth login flow with Passport using `passport-google-oauth20`
- Session middleware backed by Postgres via `connect-pg-simple`
- Clean login page at `/login`
- Routes are not protected in this PR - that is #93

## New files
| File | Purpose |
|---|---|
| `config/passport.js` | GoogleStrategy, find-or-create user logic, serialize/deserialize |
| `login.html` | Centered card with app name, tagline, Google sign-in button |

## Modified files
| File | Change |
|---|---|
| `routes/auth.js` | Replaces placeholder - adds `/login`, `/auth/google`, `/auth/google/callback`, `/auth/logout` |
| `server.js` | Adds `express-session` + `connect-pg-simple` store, `passport.initialize()`, `passport.session()` |

## Notable details
- Callback URL is dynamic: `APP_URL` env var for production, falls back to `http://localhost:3000` for local dev
- `connect-pg-simple` uses `createTableIfMissing: false` - session table already exists from #91
- DB errors in the verify function call `done(null, false)` - auth fails gracefully to `/login` rather than surfacing a stack trace
- `req.logout()` uses callback form required by Passport 0.6+
- Login page uses absolute asset paths (`/style.css`)
- If `pool` is null (no `DATABASE_URL`), `/auth/google` returns 503

## New environment variables required
| Variable | Where |
|---|---|
| `SESSION_SECRET` | `.env` + Railway |
| `GOOGLE_CLIENT_ID` | `.env` + Railway |
| `GOOGLE_CLIENT_SECRET` | `.env` + Railway |
| `APP_URL=https://somanygames.app` | Railway only (local falls back automatically) |

## Test plan
- [x] All 29 Playwright tests pass
- [x] `/login` serves login page
- [x] `/auth/google` redirects to Google consent screen
- [x] Completing OAuth creates a user row in Railway Postgres
- [x] DB connection errors redirect to `/login` rather than showing stack trace

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)