### PR TITLE
Add route protection middleware (Google OAuth)

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -31,6 +31,7 @@ jobs:
           # REQUIRED: the Anthropic SDK is instantiated at server startup (server.js line 7).
           # The server will not start without this key, regardless of whether any test
           # calls the /api/why endpoint.
+          NODE_ENV: test
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 
           # OPTIONAL: only used when the /api/spotify/playlist endpoint is called.

--- a/middleware/requireAuth.js
+++ b/middleware/requireAuth.js
@@ -1,0 +1,23 @@
+// Routes that are always accessible without authentication.
+const PUBLIC_PATHS = ["/login", "/auth/google", "/auth/google/callback", "/auth/logout"];
+
+function requireAuth(req, res, next) {
+  // In test mode, bypass auth entirely so the Playwright suite can run without
+  // OAuth credentials, a session secret, or a live database. NODE_ENV=test is
+  // set explicitly by playwright.config.js webServer.env and by the CI workflow
+  // -- it is not a general development bypass.
+  if (process.env.NODE_ENV === "test") return next();
+
+  if (PUBLIC_PATHS.includes(req.path)) return next();
+
+  if (req.isAuthenticated()) return next();
+
+  // API requests get a machine-readable 401 rather than an HTML redirect.
+  if (req.path.startsWith("/api/")) {
+    return res.status(401).json({ error: "Authentication required" });
+  }
+
+  res.redirect("/login");
+}
+
+module.exports = requireAuth;

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -14,6 +14,7 @@ module.exports = defineConfig({
     url: 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,
     timeout: 30000,
+    env: { NODE_ENV: 'test' },
   },
   reporter: process.env.CI
     ? [['github'], ['html', { open: 'never' }]]

--- a/server.js
+++ b/server.js
@@ -36,6 +36,7 @@ app.use(
 
 app.use(passport.initialize());
 app.use(passport.session());
+app.use(require("./middleware/requireAuth"));
 
 app.use(require("./routes/auth"));
 app.use(require("./routes/api"));


### PR DESCRIPTION
## Summary
Completes the Google OAuth implementation by protecting all routes behind authentication. Unauthenticated users are redirected to `/login`; unauthenticated API requests get a 401 JSON response.

This PR also contains the work from #90, #91, and #92 - all on the same branch.

## New files
| File | Purpose |
|---|---|
| `middleware/requireAuth.js` | Blocks unauthenticated requests; API vs browser detection; test bypass |

## Changes
| File | Change |
|---|---|
| `server.js` | Mounts `requireAuth` after `passport.session()`, before all routes |
| `playwright.config.js` | Adds `env: { NODE_ENV: 'test' }` to webServer block |
| `.github/workflows/playwright.yml` | Adds `NODE_ENV: test` to CI env block |

## How the bypass works
`NODE_ENV=test` causes `requireAuth` to call `next()` immediately, skipping all auth checks. This value is set explicitly by `playwright.config.js` (for local test runs) and by the CI workflow (for GitHub Actions) - it is not a general development bypass. Documented in a comment in the middleware file.

## Route protection rules
| Route | Behavior |
|---|---|
| `/login`, `/auth/google`, `/auth/google/callback`, `/auth/logout` | Always public |
| `/api/*` (unauthenticated) | 401 `{ error: "Authentication required" }` |
| All other routes (unauthenticated) | 302 redirect to `/login` |
| Any route (authenticated) | Pass through |

## Verification
- [x] 29/29 Playwright tests pass (`NODE_ENV=test` bypass active)
- [x] `GET /` redirects to `/login` when unauthenticated (302)
- [x] `POST /api/why` returns 401 JSON when unauthenticated
- [x] `GET /login` returns 200 without auth
- [x] Google sign-in flow completes and lands on the main app

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)