### PR TITLE
Add BGG link badge to suggested game cards

### DIFF
--- a/app.js
+++ b/app.js
@@ -596,6 +596,9 @@ function renderResults(picked, heading) {
           <span>🎂 Ages ${game.age}+</span>
           ${game.cooperative ? '<span class="coop-tag">🤝 Co-op</span>' : ''}
           <span>${game.played ? '✓ Played before' : '✨ New to us'}</span>
+          <a class="lib-badge lib-bgg-badge" data-testid="bgg-badge"
+            href="${game.bggId ? `https://boardgamegeek.com/boardgame/${game.bggId}` : `https://www.google.com/search?q=${encodeURIComponent(game.name + ' board game')}`}"
+            target="_blank" rel="noopener" onclick="event.stopPropagation()">BGG↗</a>
         </div>
         <button class="lets-play-btn" data-testid="lets-play-btn" onclick="event.stopPropagation(); openSession(${index})">Let's Play!</button>
       </div>

--- a/tests/app.spec.js
+++ b/tests/app.spec.js
@@ -137,6 +137,50 @@ test('quick search filters visible games', async ({ page }) => {
   }
 });
 
+// ── BGG badge on game cards ────────────────────────────────────────────────
+test('expanded game card shows BGG badge linking to boardgamegeek.com for a BGG game', async ({ page }) => {
+  const main = new MainPage(page);
+
+  await page.evaluate(() => {
+    localStorage.setItem('sz-games', JSON.stringify([
+      { name: 'Ticket to Ride', minPlayers: 2, maxPlayers: 5, playTime: 60,
+        complexity: 'Low', type: 'Board', age: 8, setupTime: 10, rating: 4,
+        played: false, cooperative: false, thumbnail: null, bggId: 9209, source: 'bgg' },
+    ]));
+  });
+  await page.reload();
+
+  await main.findGames();
+  await main.expandGameCard(0);
+
+  const badge = main.gameCards().nth(0).getByTestId('bgg-badge');
+  await expect(badge).toBeVisible();
+  await expect(badge).toHaveAttribute('href', 'https://boardgamegeek.com/boardgame/9209');
+  await expect(badge).toHaveAttribute('target', '_blank');
+});
+
+test('expanded game card shows BGG badge linking to Google search for a manual game', async ({ page }) => {
+  const main = new MainPage(page);
+
+  await page.evaluate(() => {
+    localStorage.setItem('sz-games', JSON.stringify([
+      { name: 'My Homebrew Game', minPlayers: 2, maxPlayers: 4, playTime: 30,
+        complexity: 'Low', type: 'Card', age: 0, setupTime: 5, rating: null,
+        played: false, cooperative: false, thumbnail: null, bggId: null, source: 'manual' },
+    ]));
+  });
+  await page.reload();
+
+  await main.findGames();
+  await main.expandGameCard(0);
+
+  const badge = main.gameCards().nth(0).getByTestId('bgg-badge');
+  await expect(badge).toBeVisible();
+  const href = await badge.getAttribute('href');
+  expect(href).toContain('google.com/search');
+  expect(href).toContain('My%20Homebrew%20Game');
+});
+
 // ── Session Modal ──────────────────────────────────────────────────────────
 test("Let's Play opens session modal with game title", async ({ page }) => {
   const main    = new MainPage(page);


### PR DESCRIPTION
## Summary

- Adds a BGG badge to each expanded game card in the main results view
- Badge links to `boardgamegeek.com/boardgame/<id>` when `bggId` is present
- Falls back to a Google search for the game name when `bggId` is null (manually added games)
- Badge opens in a new tab; click does not expand/collapse the card

## Tests

- BGG game badge links to correct BGG URL
- Manual game badge (no bggId) falls back to Google search URL containing the game name

## Test plan

- [x] All 31 Playwright tests pass
- [x] Badge appears when a game card is expanded
- [x] BGG game badge opens correct BGG page
- [x] Manual game badge opens Google search fallback

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)