### PR TITLE
Remove temporary Railway diagnostic debug logs

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,4 +1,3 @@
-console.log('[DEBUG] env keys:', Object.keys(process.env).filter(k => !k.includes('npm') && !k.includes('NODE')));
 require("dotenv").config();
 const express = require("express");
 const session = require("express-session");


### PR DESCRIPTION
## Summary

- Removes `console.log('[DEBUG] env keys:', ...)` from `server.js` that was added to diagnose Railway environment variable injection

The log confirmed `GOOGLE_CLIENT_ID` is present in the Railway process at startup. Diagnosis complete.

## Test plan

- [x] No functional changes - cleanup only
- [x] CI should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)