### PR TITLE
Add .claude/commands/ slash commands

### DIFF
--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -1,0 +1,5 @@
+# /project:implement
+Implement the plan for $ARGUMENTS.
+Full execution loop: write code, run tests, fix failures.
+Only open a PR when all tests pass.
+PR description must include Closes #[issue number].

--- a/.claude/commands/issue.md
+++ b/.claude/commands/issue.md
@@ -1,0 +1,3 @@
+# /project:issue
+Using the template in /prompts/create-github-issues.md, create a GitHub Issue for:
+$ARGUMENTS

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -1,0 +1,7 @@
+# /project:plan
+Show me your implementation plan for $ARGUMENTS. Do not write any code yet.
+Follow these constraints:
+- Tests use Page Object Model -- no raw selectors in test files
+- External APIs are mocked with page.route() -- never hit live APIs in tests
+- Scope stays focused -- one feature per plan
+- Flag any architectural decisions that need human review before implementing

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -1,0 +1,9 @@
+# /project:review
+Review the current open PR against the acceptance criteria in its linked issue.
+Check for:
+- All acceptance criteria met
+- Tests follow Page Object Model -- no raw selectors
+- No live API calls in tests -- all external APIs mocked with page.route()
+- PR description includes Closes #[issue number]
+- No em dashes in any file
+Report what passes, what fails, and what is missing.


### PR DESCRIPTION
## Summary

- Adds `.claude/commands/plan.md` -- show implementation plan, no code, with project constraints
- Adds `.claude/commands/implement.md` -- full code/test/fix/PR loop
- Adds `.claude/commands/issue.md` -- create GitHub Issues via project template
- Adds `.claude/commands/review.md` -- review open PR against acceptance criteria, POM, API mocking, em dash check

## Test plan

- [x] No functional changes -- documentation/tooling only
- [x] Commands are accessible via `/project:<name>` in Claude Code

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)