### PR TITLE
Migrate Player Vault to database (#108)

### DIFF
--- a/app.js
+++ b/app.js
@@ -21,7 +21,7 @@ let renderedGames = [];
 // Player Vault (permanent registry)
 const AVATAR_COLORS = ['#e05252','#f5a842','#5dd67a','#52a8e0','#c275e0','#e91e8c','#f5c842'];
 const AVATAR_EMOJIS = ['🎮','🎲','🃏','🧩','♟️','🎯','🎪','🦁','🐉','🦊','🐺','🦝','🎭','🤖','👾','🧙','🧝','🧛','🎩','⚔️','🏴‍☠️','🐸','🐧','🦄'];
-let vault = isDemoMode() ? [] : JSON.parse(localStorage.getItem('sz-vault') || '[]');
+let vault = []; // populated by initVault() on load, or by demo mode synchronously
 let emojiPickerTarget = null; // vault player id
 
 // Roll Call (who's playing tonight — session state)
@@ -100,8 +100,58 @@ if (isDemoMode()) {
 renderRollCall();
 renderGamesInProgress();
 applySettings();
+if (!isDemoMode()) {
+  initVault();
+}
 
 // ── Player Vault ───────────────────────────────────────────────────────────
+function normalizePlayer(p) {
+  return { id: String(p.id), name: p.name, emoji: p.emoji, color: p.color, lastPlayed: p.last_played ?? null };
+}
+
+async function initVault() {
+  try {
+    const res = await fetch('/api/players');
+    if (!res.ok) return;
+    vault = (await res.json()).map(normalizePlayer);
+  } catch {
+    // Network error - vault stays empty
+  }
+  renderRollCall();
+  checkLocalStorageImport();
+}
+
+function checkLocalStorageImport() {
+  if (vault.length > 0) return;
+  const legacy = JSON.parse(localStorage.getItem('sz-vault') || '[]');
+  if (legacy.length === 0) return;
+  document.getElementById('vault-import-prompt')?.classList.remove('hidden');
+}
+
+async function importLocalVault() {
+  const legacy = JSON.parse(localStorage.getItem('sz-vault') || '[]');
+  for (const p of legacy) {
+    try {
+      const res = await fetch('/api/players', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: p.name, emoji: p.emoji, color: p.color }),
+      });
+      if (res.ok) vault.push(normalizePlayer(await res.json()));
+    } catch {}
+  }
+  vault.sort((a, b) => a.name.localeCompare(b.name));
+  localStorage.removeItem('sz-vault');
+  document.getElementById('vault-import-prompt')?.classList.add('hidden');
+  renderVaultList();
+  renderRollCall();
+}
+
+function dismissImportPrompt() {
+  localStorage.removeItem('sz-vault');
+  document.getElementById('vault-import-prompt')?.classList.add('hidden');
+}
+
 function openVault() {
   renderVaultList();
   document.getElementById('vault-modal').classList.add('active');
@@ -112,7 +162,7 @@ function closeVault() {
   document.getElementById('vault-modal').classList.remove('active');
 }
 
-function addToVault() {
+async function addToVault() {
   const input = document.getElementById('vault-name-input');
   const name = input.value.trim();
   if (!name) return;
@@ -123,13 +173,29 @@ function addToVault() {
     return;
   }
   const color = AVATAR_COLORS[vault.length % AVATAR_COLORS.length];
-  vault.push({ id: Date.now().toString(), name, emoji: null, color, lastPlayed: null });
-  vault.sort((a, b) => a.name.localeCompare(b.name));
-  saveVault();
-  renderVaultList();
-  renderRollCall();
-  input.value = '';
-  input.focus();
+  if (isDemoMode()) {
+    vault.push({ id: Date.now().toString(), name, emoji: null, color, lastPlayed: null });
+    vault.sort((a, b) => a.name.localeCompare(b.name));
+    renderVaultList();
+    renderRollCall();
+    input.value = '';
+    input.focus();
+    return;
+  }
+  try {
+    const res = await fetch('/api/players', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, emoji: null, color }),
+    });
+    if (!res.ok) return;
+    vault.push(normalizePlayer(await res.json()));
+    vault.sort((a, b) => a.name.localeCompare(b.name));
+    renderVaultList();
+    renderRollCall();
+    input.value = '';
+    input.focus();
+  } catch {}
 }
 
 function formatLastPlayed(dateStr) {
@@ -137,18 +203,17 @@ function formatLastPlayed(dateStr) {
   return new Date(dateStr).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: '2-digit' });
 }
 
-function removeFromVault(id) {
+async function removeFromVault(id) {
+  if (!isDemoMode()) {
+    try {
+      await fetch(`/api/players/${id}`, { method: 'DELETE' });
+    } catch {}
+  }
   vault = vault.filter(p => p.id !== id);
   rollCall.delete(id);
-  saveVault();
   renderVaultList();
   renderRollCall();
   syncPlayersFilter();
-}
-
-function saveVault() {
-  if (isDemoMode()) return;
-  localStorage.setItem('sz-vault', JSON.stringify(vault));
 }
 
 function renderVaultList() {
@@ -237,7 +302,13 @@ function selectPlayerEmoji(emoji) {
     const player = vault.find(p => p.id === emojiPickerTarget);
     if (player) {
       player.emoji = emoji;
-      saveVault();
+      if (!isDemoMode()) {
+        fetch(`/api/players/${player.id}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ emoji }),
+        }).catch(() => {});
+      }
       renderVaultList();
       renderRollCall();
     }
@@ -250,7 +321,13 @@ function clearPlayerEmoji() {
     const player = vault.find(p => p.id === emojiPickerTarget);
     if (player) {
       player.emoji = null;
-      saveVault();
+      if (!isDemoMode()) {
+        fetch(`/api/players/${player.id}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ emoji: null }),
+        }).catch(() => {});
+      }
       renderVaultList();
       renderRollCall();
     }
@@ -1012,9 +1089,17 @@ function saveResult(result) {
   // Stamp lastPlayed on each participating vault player
   result.players.forEach(rp => {
     const vp = vault.find(v => v.id === rp.id);
-    if (vp) vp.lastPlayed = result.date;
+    if (vp) {
+      vp.lastPlayed = result.date;
+      if (!isDemoMode()) {
+        fetch(`/api/players/${vp.id}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ last_played: result.date }),
+        }).catch(() => {});
+      }
+    }
   });
-  saveVault();
 }
 
 // ── Session Lifecycle ──────────────────────────────────────────────────────

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -7,6 +7,16 @@ CREATE TABLE IF NOT EXISTS users (
   created_at TIMESTAMPTZ DEFAULT NOW()
 );
 
+CREATE TABLE IF NOT EXISTS players (
+  id          SERIAL PRIMARY KEY,
+  user_id     INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  name        TEXT NOT NULL,
+  emoji       TEXT,
+  color       TEXT,
+  last_played TIMESTAMPTZ,
+  created_at  TIMESTAMPTZ DEFAULT NOW()
+);
+
 CREATE TABLE IF NOT EXISTS session (
   sid VARCHAR NOT NULL PRIMARY KEY,
   sess JSON NOT NULL,

--- a/index.html
+++ b/index.html
@@ -33,6 +33,12 @@
       <div id="roll-call-chips" data-testid="roll-call-chips" class="roll-call-chips"></div>
     </section>
 
+    <div id="vault-import-prompt" data-testid="vault-import-prompt" class="vault-import-prompt hidden">
+      <span>We found players on this device. Import them to your account?</span>
+      <button onclick="importLocalVault()" data-testid="vault-import-yes">Import</button>
+      <button onclick="dismissImportPrompt()" data-testid="vault-import-no">No thanks</button>
+    </div>
+
     <section class="games-in-progress hidden" id="games-in-progress">
       <h2 class="section-label">Games in Progress</h2>
       <div id="gip-list" class="gip-list"></div>

--- a/routes/api.js
+++ b/routes/api.js
@@ -1,8 +1,77 @@
 const express = require("express");
 const Anthropic = require("@anthropic-ai/sdk");
+const pool = require("../db/index");
 
 const router = express.Router();
 const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+
+// ── Players ────────────────────────────────────────────────────────────────
+router.get("/api/players", async (req, res) => {
+  if (!pool) return res.json([]);
+  try {
+    const { rows } = await pool.query(
+      "SELECT id, name, emoji, color, last_played FROM players WHERE user_id = $1 ORDER BY name",
+      [req.user.id]
+    );
+    res.json(rows);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+router.post("/api/players", async (req, res) => {
+  if (!pool) return res.status(503).json({ error: "Database not available" });
+  const { name, emoji, color } = req.body;
+  if (!name?.trim()) return res.status(400).json({ error: "name required" });
+  try {
+    const { rows } = await pool.query(
+      "INSERT INTO players (user_id, name, emoji, color) VALUES ($1, $2, $3, $4) RETURNING id, name, emoji, color, last_played",
+      [req.user.id, name.trim(), emoji ?? null, color ?? null]
+    );
+    res.status(201).json(rows[0]);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+router.put("/api/players/:id", async (req, res) => {
+  if (!pool) return res.status(503).json({ error: "Database not available" });
+  const updates = [];
+  const vals = [];
+  let idx = 1;
+  if ("emoji" in req.body)       { updates.push(`emoji = $${idx++}`);       vals.push(req.body.emoji); }
+  if ("color" in req.body)       { updates.push(`color = $${idx++}`);       vals.push(req.body.color); }
+  if ("last_played" in req.body) { updates.push(`last_played = $${idx++}`); vals.push(req.body.last_played); }
+  if (!updates.length) return res.status(400).json({ error: "Nothing to update" });
+  vals.push(req.params.id, req.user.id);
+  try {
+    const { rows } = await pool.query(
+      `UPDATE players SET ${updates.join(", ")} WHERE id = $${idx} AND user_id = $${idx + 1} RETURNING id, name, emoji, color, last_played`,
+      vals
+    );
+    if (!rows.length) return res.status(404).json({ error: "Player not found" });
+    res.json(rows[0]);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+router.delete("/api/players/:id", async (req, res) => {
+  if (!pool) return res.status(503).json({ error: "Database not available" });
+  try {
+    await pool.query(
+      "DELETE FROM players WHERE id = $1 AND user_id = $2",
+      [req.params.id, req.user.id]
+    );
+    res.json({});
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: err.message });
+  }
+});
 
 // ── Spotify ────────────────────────────────────────────────────────────────
 let spotifyToken = null;

--- a/style.css
+++ b/style.css
@@ -2381,6 +2381,38 @@ body.hide-why .why-btn {
 }
 
 /* ── Demo Mode ──────────────────────────────────────────────────────────── */
+.vault-import-prompt {
+  background: #1a2a4a;
+  border: 1px solid #2a3a5e;
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  margin: 0.75rem 0;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.875rem;
+  color: #c8d8f8;
+}
+
+.vault-import-prompt button {
+  padding: 0.3rem 0.8rem;
+  border-radius: 6px;
+  border: none;
+  cursor: pointer;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.vault-import-prompt button:first-of-type {
+  background: #5b9cf6;
+  color: #0a0f1e;
+}
+
+.vault-import-prompt button:last-of-type {
+  background: #2a3a5e;
+  color: #9ab;
+}
+
 .demo-banner {
   position: sticky;
   top: 0;

--- a/tests/app.spec.js
+++ b/tests/app.spec.js
@@ -20,7 +20,38 @@ const MOCK_PLAYLISTS = {
 
 // Each test gets a fresh localStorage so state doesn't bleed between runs.
 // waitForLoadState('networkidle') ensures games.json fetch completes first.
+// /api/players is mocked so tests never hit the real database. The mock is
+// stateful within each test -- state resets between tests because mockPlayers
+// is declared in the beforeEach closure.
 test.beforeEach(async ({ page }) => {
+  let mockPlayers = [];
+  let nextId = 1;
+
+  await page.route(url => url.href.includes('/api/players'), async (route) => {
+    const method = route.request().method();
+    const url = route.request().url();
+    const idSegment = url.match(/\/api\/players\/(\d+)/)?.[1];
+
+    if (method === 'GET') {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(mockPlayers) });
+    } else if (method === 'POST') {
+      const body = route.request().postDataJSON();
+      const player = { id: nextId++, name: body.name, emoji: body.emoji ?? null, color: body.color ?? '#52a8e0', last_played: null };
+      mockPlayers.push(player);
+      await route.fulfill({ status: 201, contentType: 'application/json', body: JSON.stringify(player) });
+    } else if (method === 'PUT' && idSegment) {
+      const id = parseInt(idSegment);
+      const body = route.request().postDataJSON();
+      const idx = mockPlayers.findIndex(p => p.id === id);
+      if (idx !== -1) mockPlayers[idx] = { ...mockPlayers[idx], ...body };
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(mockPlayers[idx] ?? {}) });
+    } else if (method === 'DELETE' && idSegment) {
+      const id = parseInt(idSegment);
+      mockPlayers = mockPlayers.filter(p => p.id !== id);
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({}) });
+    }
+  });
+
   await page.goto('/');
   await page.evaluate(() => localStorage.clear());
   await page.reload();
@@ -55,6 +86,61 @@ test('rejects duplicate player names', async ({ page }) => {
   await vault.addPlayer('Bob');
   await vault.addPlayer('bob'); // duplicate — different case
   await expect(vault.list.getByTestId('vault-player').filter({ hasText: 'Bob' })).toHaveCount(1);
+});
+
+test('adding a player to the vault persists after reload', async ({ page }) => {
+  // The beforeEach mock is stateful: POST adds Alice to mockPlayers, so the next
+  // GET (on reload) returns her. Clearing localStorage proves the data came from
+  // the API mock and not localStorage.
+  const vault = new VaultModal(page);
+  await vault.open();
+  await vault.addPlayer('Alice');
+  await vault.expectPlayer('Alice');
+
+  await page.waitForLoadState('networkidle');
+  await page.evaluate(() => localStorage.clear());
+  await page.reload();
+  await page.waitForLoadState('networkidle');
+
+  await vault.open();
+  await vault.expectPlayer('Alice');
+});
+
+test('deleting a player from the vault persists after reload', async ({ page }) => {
+  // Seed the mock with Bob pre-loaded so we can test that deletion removes him
+  // from the API state, not just from the in-memory vault.
+  let mockPlayers = [{ id: 99, name: 'Bob', emoji: null, color: '#52a8e0', last_played: null }];
+
+  await page.route(url => url.href.includes('/api/players'), async (route) => {
+    const method = route.request().method();
+    const url = route.request().url();
+    const idSegment = url.match(/\/api\/players\/(\d+)/)?.[1];
+
+    if (method === 'GET') {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(mockPlayers) });
+    } else if (method === 'DELETE' && idSegment) {
+      const id = parseInt(idSegment);
+      mockPlayers = mockPlayers.filter(p => p.id !== id);
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({}) });
+    }
+  });
+
+  await page.reload();
+  await page.waitForLoadState('networkidle');
+
+  const vault = new VaultModal(page);
+  await vault.open();
+  await vault.expectPlayer('Bob');
+
+  await vault.removePlayer('Bob');
+  await vault.expectNoPlayer('Bob');
+
+  await page.waitForLoadState('networkidle');
+  await page.reload();
+  await page.waitForLoadState('networkidle');
+
+  await vault.open();
+  await vault.expectNoPlayer('Bob');
 });
 
 // ── Roll Call ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Replaces `localStorage sz-vault` with a `players` Postgres table and REST API
- Players now persist across devices and browsers for authenticated users
- Demo mode behavior unchanged -- all API calls bypassed in demo

## What changed

**Database:** Added `players` table (`id`, `user_id`, `name`, `emoji`, `color`, `last_played`, `created_at`) to `schema.sql`. Auto-migrated on server start.

**Routes (`routes/api.js`):**
- `GET /api/players` - returns all players for authenticated user, ordered by name
- `POST /api/players` - creates a player, returns new row
- `PUT /api/players/:id` - partial update (only fields present in body updated, so avatar changes and lastPlayed stamps don't overwrite each other)
- `DELETE /api/players/:id` - removes a player (scoped to user_id)

**Frontend (`app.js`):**
- `vault[]` starts empty; `initVault()` fetches `/api/players` on load
- `addToVault()` now async: POSTs to API, pushes normalized response
- `removeFromVault()` now async: DELETEs from API before filtering local vault
- Avatar changes (`selectPlayerEmoji`, `clearPlayerEmoji`): fire-and-forget PUT
- `saveResult()` lastPlayed stamp: fire-and-forget PUT instead of `saveVault()`
- `saveVault()` removed entirely
- Import prompt shown on first login when `sz-vault` found in localStorage

**ID type change -- all comparison sites audited:**

`normalizePlayer()` stringifies the DB integer id at the API boundary. All downstream comparisons use strings consistently:

| Location | Variable | Source | Safe? |
|---|---|---|---|
| `removeFromVault(id)` | `id` param | `onclick="removeFromVault('${p.id}')"` (HTML attr) | String ✓ |
| `openEmojiPicker(playerId)` | `emojiPickerTarget` | `onclick="openEmojiPicker('${player.id}')"` | String ✓ |
| `toggleRollCall(id)` / `rollCall.has(p.id)` | rollCall Set entries | `onclick="toggleRollCall('${p.id}')"` | String ✓ |
| `addSessionPlayer(select)` | `select.value` | `<option value="${p.id}">` | String ✓ |
| `sessionScores[player.id]` | key | from vault player | String ✓ |
| `vault.find(v => v.id === rp.id)` | `rp.id` | serialized from sessionPlayers | String ✓ |
| `vault.find(v => v.id === p.id)` in history render | `p.id` | stored from vault at session time | String ✓ |
| `h2hSelected[side] === id` | `id` | `onclick="selectH2HPlayer('${side}', '${p.id}')"` | String ✓ |

Historical sessions recorded before migration have timestamp-string player ids that won't match new DB ids. Acceptable -- will be addressed by Issue #111 (Migrate Play History).

**Tests (`tests/app.spec.js`):**
- `beforeEach` now mocks `/api/players` with a stateful in-test closure (GET/POST/PUT/DELETE). No test hits the real database.
- Two new tests added per acceptance criteria:
  - `adding a player to the vault persists after reload` - clears localStorage before reload to prove persistence is API-based
  - `deleting a player from the vault persists after reload` - uses pre-seeded mock state to prove DELETE propagates

## Test plan

- [x] All 40 Playwright tests pass
- [x] `adding a player to the vault persists after reload` - new, passing
- [x] `deleting a player from the vault persists after reload` - new, passing
- [x] Demo mode tests unaffected (API bypassed, localStorage not written)
- [x] Existing vault tests (`can add and remove`, `rejects duplicate`, `roll call`) pass with mock

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)