### PR TITLE
Restructure UI navigation for desktop and responsive

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,13 +7,17 @@ Session Zero is a vanilla HTML/CSS/JS + Node.js game night planning web app. Pla
 
 ## Tech Stack
 - Frontend: Vanilla HTML, CSS, JavaScript (no frameworks, no build step - intentional)
-- Backend: Node.js with built-in http module (no Express)
+- Backend: Node.js with Express
+- Auth: Google OAuth 2.0 via Passport.js
+- Sessions: express-session backed by Postgres via connect-pg-simple
+- Database: PostgreSQL (Railway)
 - AI: Anthropic Claude API (claude-opus-4-6)
 - Music: Spotify Web API + Spotify Embed Player
 - Testing: Playwright with Page Object Model
 - CI/CD: GitHub Actions
+- Hosting: Railway (somanygames.app)
 - Version control: Git + GitHub
-- Data: games.json (local), migrating to BoardGameGeek API
+- Data: Migrating from localStorage to Postgres (see Migration State below)
 
 ## Commands
 
@@ -43,34 +47,131 @@ npx playwright test --ui
 There is no bundler, transpiler, or framework. `index.html` is served directly. `app.js` and `style.css` are loaded as-is. Changes take effect on browser reload.
 
 ### Server (server.js)
-Three API routes, everything else is static file serving:
-- `POST /api/why` - sends game + filter context to Claude API, streams back a recommendation explanation
-- `GET /api/spotify/playlist?game=&type=` or `?query=` - fetches a playlist from Spotify and returns up to 5 results as `{ playlists: [{ embedUrl, name }] }`
-- `GET /api/bgg/collection?username=` - proxies BoardGameGeek XML API, parses it, returns normalized game objects (blocked on BGG API token)
+Entry point. Sets up Express middleware in this exact order -- do not reorder:
+1. dotenv
+2. express()
+3. CORS header
+4. express.json()
+5. migrate() - fire-and-forget DB warmup
+6. session middleware - backed by Postgres when DATABASE_URL is set
+7. passport config
+8. passport.initialize() and passport.session()
+9. requireAuth middleware
+10. routes/auth.js
+11. routes/api.js
+12. routes/static.js
+13. app.listen()
+
+### Routes
+- `POST /api/why` - streams Claude API recommendation explanation
+- `GET /api/spotify/playlist` - fetches Spotify playlists by game name
+- `GET /api/bgg/collection` - proxies BGG XML API, returns normalized game objects
+- `GET /api/players` - returns vault players for authenticated user
+- `POST /api/players` - creates a player
+- `PUT /api/players/:id` - updates player fields
+- `DELETE /api/players/:id` - removes a player
+- `GET /login` - serves login.html landing page
+- `GET /demo` - serves index.html in demo mode
+- `GET /auth/google` - initiates Google OAuth flow
+- `GET /auth/google/callback` - handles OAuth callback, finds or creates user
+- `GET /auth/logout` - destroys session, redirects to /login
+
+### Authentication
+- Google OAuth via Passport. `req.user` contains `{ id, google_id, email, display_name, avatar_url }` on all authenticated routes.
+- `NODE_ENV=test` bypasses requireAuth entirely -- intentional for CI. This means Playwright tests cannot observe auth-blocking behavior. Use Jest unit tests for auth middleware logic.
+- Static assets (.js, .css, .json) bypass requireAuth via file extension check -- never require auth for static files.
+
+### Demo mode
+- `/demo` serves the full app with static demo data and fictional players.
+- `isDemoMode()` in app.js gates all API calls and localStorage writes.
+- Demo players are hardcoded: Colonel Mustard, Miss Scarlett, Professor Plum, Mrs. Peacock.
+- Demo data lives in `demo-games.json` -- Paul controls this file manually.
+- Never modify demo behavior as a side effect of other changes.
+- Never write real data to the database from demo mode.
 
 ### Frontend (app.js)
-Single 1800-line file organized into sections marked with `// ── Section Name ──` comments. Sections map directly to features: Player Vault, Roll Call, Settings, Filters, Game Cards, Why?, Session Modal, Spotify, Score Tracker, Timer, Dice Roller, Play History, Player Stats, Game Library, Quick Search.
+Single file organized into sections marked with `// -- Section Name --` comments. Sections: Player Vault, Roll Call, Settings, Filters, Game Cards, Why?, Session Modal, Spotify, Score Tracker, Timer, Dice Roller, Play History, Player Stats, Game Library, Quick Search.
 
 All state is module-level `let` variables at the top of the file. No state management library.
 
-### Data / localStorage
-All persistence is localStorage. Keys:
-- `sz-games` - game library array (overrides games.json if present)
-- `sz-vault` - permanent player registry
-- `sz-settings` - user preferences (showWhyBtn, bggUsername, bggLastSync)
-- `sz-history` - finalized session results
-- `sz-active-sessions` - paused (in-progress) sessions
-
-On startup, `sz-games` is loaded from localStorage if present, otherwise fetched from `games.json`.
+### Player IDs
+Player IDs are Postgres integers stringified at the API boundary via `normalizePlayer()`. All code that compares player IDs already goes through this function. Never compare raw IDs without normalizing first -- `'123' !== 123` bugs are real and have bitten us before.
 
 ### Modal pattern
-Every modal is a `<div>` with a unique `data-testid`. Active state is toggled via `.classList.add('active')`. Session Dashboard is the main complex modal - it contains Score Tracker, Timer, Dice Roller, and Spotify panels as sub-sections within a left/right split layout.
+Every modal is a `<div>` with a unique `data-testid`. Active state is toggled via `.classList.add('active')`. Session Dashboard is the main complex modal containing Score Tracker, Timer, Dice Roller, and Spotify panels in a left/right split layout.
 
 ### Session lifecycle
-`openSession(index)` sets the global `sessionGame` and `sessionPlayers`, then initializes all sub-components (score tracker, timer, dice, Spotify). `pauseSession()` serializes full state to `sz-active-sessions`. `resumeSession(id)` restores it. `finalizeSession()` writes to `sz-history` and clears the active session.
+`openSession(index)` sets global `sessionGame` and `sessionPlayers`, initializes all sub-components. `pauseSession()` serializes full state to `sz-active-sessions`. `resumeSession(id)` restores it. `finalizeSession()` writes to `sz-history` and clears the active session.
 
 ### Tests (tests/)
-All tests live in `tests/app.spec.js`. Page objects live in `tests/pages/`. Each page object maps to one modal or page area. `beforeEach` clears localStorage and reloads so tests are fully isolated. The `playwright.config.js` `webServer` block starts `node server.js` automatically - no manual server startup needed for tests.
+All tests live in `tests/app.spec.js`. Page objects live in `tests/pages/`. Each page object maps to one modal or page area. `beforeEach` clears localStorage and reloads -- tests are fully isolated. The `playwright.config.js` `webServer` block starts the server automatically with `NODE_ENV=test`.
+
+## Current Migration State
+
+Migrating from localStorage to Postgres. Before touching any persistence code, check this table:
+
+| Data | Storage | Status |
+|---|---|---|
+| Player Vault | Postgres | Complete (#108) |
+| Settings | localStorage | Pending (#109) |
+| Game Library | localStorage | Pending (#110) |
+| Play History | localStorage | Pending (#111) |
+| Active Sessions | localStorage | Pending (#111) |
+
+Never write new localStorage persistence for Player Vault data -- it lives in the database.
+When touching any other data, check this table before choosing localStorage vs API call.
+
+## Core Principles
+
+### 1. Think Before Coding
+Don't assume. Don't hide confusion. Surface tradeoffs.
+
+- State assumptions explicitly -- if uncertain, ask rather than guess
+- Present multiple interpretations -- don't pick silently when ambiguity exists
+- Push back when warranted -- if a simpler approach exists, say so
+- Stop when confused -- name what's unclear and ask for clarification
+- Always present a plan before implementing anything destructive or architectural
+
+### 2. Simplicity First
+Minimum code that solves the problem. Nothing speculative.
+
+- No features beyond what was asked
+- No abstractions for single-use code
+- No flexibility or configurability that wasn't requested
+- No error handling for impossible scenarios
+- If 200 lines could be 50, rewrite it
+
+The test: would a senior engineer say this is overcomplicated? If yes, simplify.
+
+### 3. Surgical Changes
+Touch only what you must. Clean up only your own mess.
+
+- Don't improve adjacent code, comments, or formatting unless asked
+- Don't refactor things that aren't broken
+- Match existing style, even if you'd do it differently
+- If you notice something wrong outside the scope of the task: mention it, do not fix it, do not create a branch for it. Paul will decide whether to create an issue.
+- Remove imports/variables/functions that YOUR changes made unused
+- Don't remove pre-existing dead code unless asked
+- Every changed line should trace directly to the request
+
+### 4. Goal-Driven Execution
+Define success criteria. Loop until verified.
+
+- Write failing tests first, then implement until green (TDD loop)
+- For multi-step tasks, state a brief plan with a verification step for each
+- PRs are only opened when all tests pass -- not before
+- Use /compact when sessions get long to preserve output quality
+
+## Testing Standards
+
+- All tests use Page Object Model -- no raw selectors anywhere in test files
+- External APIs are mocked with `page.route()` -- never hit live APIs in tests
+- Every test is fully isolated -- `beforeEach` clears all state, tests never share data
+- Seed test state via `page.evaluate()` directly into localStorage or memory
+- New features require tests for: happy path, empty/zero state, error state, edge cases
+- API integrations require tests for: success response, failure response, loading state
+- Test names describe behavior, not implementation: "adding a player persists after reload" not "POST /api/players works"
+- The Why? button (/api/why) is never tested with Playwright -- it hits a paid API
 
 ## Conventions
 - Branch names: feature/short-description or fix/short-description
@@ -78,25 +179,24 @@ All tests live in `tests/app.spec.js`. Page objects live in `tests/pages/`. Each
 - One issue per branch, one feature per PR
 - PR descriptions always include Closes #n referencing the issue
 - Commit messages explain why, not just what
-- Test files use Page Object Model - no raw selectors in test files
-- External APIs are mocked in tests using page.route() - never hit live APIs in tests
 - Never use em dashes in any file. Use commas, semicolons, colons, regular dashes, or parentheses instead.
-- Always ask "show me your plan first" before any new feature implementation
-- New features follow TDD loop: write failing test first, then implement until green
 
 ## Files You Should Never Modify Directly
-- .env (environment variables - never touch)
-- package-lock.json (only modified by npm)
-- games.json (game data - only modify if explicitly asked)
-- .github/workflows/ (CI config - only modify if explicitly asked)
+- `.env` - environment variables, never touch
+- `package-lock.json` - only modified by npm
+- `games.json` - game data, only modify if explicitly asked
+- `demo-games.json` - demo library, Paul controls this manually
+- `.github/workflows/` - CI config, only modify if explicitly asked
+- `db/schema.sql` - database schema, only modify if explicitly asked
+- `config/passport.js` - auth configuration, touch carefully and only if asked
+- `middleware/requireAuth.js` - security-critical, changes require explicit approval
 
 ## Working Approach
-- Always present a plan before implementing anything destructive or architectural
-- Run tests after implementation - PRs only get opened when tests pass
-- Scope stays focused - one feature or fix per session
-- Use /compact when the session gets long to preserve output quality
+- Always ask "show me your plan first" before any new feature implementation
+- Run tests after implementation -- PRs only open when tests pass
+- Scope stays focused -- one feature or fix per session
 - When creating GitHub Issues, follow the template in /prompts/create-github-issues.md
 - The prompt library lives in /prompts/ -- check it before starting any repeatable task
-- Use /project:plan before any implementation -- never skip the plan step
-- Use /project:issue to create GitHub Issues -- keeps prompt library in sync
-- Use /project:review before merging any PR
+- Use /plan before any implementation -- never skip the plan step
+- Use /issue to create GitHub Issues -- keeps prompt library in sync
+- Use /review before merging any PR

--- a/app.js
+++ b/app.js
@@ -82,7 +82,7 @@ if (isDemoMode()) {
 
   // Show demo UI
   document.getElementById('demo-banner').classList.remove('hidden');
-  document.getElementById('demo-header-signin').classList.remove('hidden');
+  document.getElementById('demo-header-signin')?.classList.remove('hidden');
 } else {
   const storedGames = localStorage.getItem('sz-games');
   if (storedGames) {
@@ -102,6 +102,42 @@ renderGamesInProgress();
 applySettings();
 if (!isDemoMode()) {
   initVault();
+}
+
+// ── Navigation ─────────────────────────────────────────────────────────────
+function setActiveNav(name) {
+  document.querySelectorAll('.nav-item, .mobile-nav-item').forEach(btn => {
+    btn.classList.toggle('active', btn.dataset.nav === name);
+  });
+}
+
+function closeAllSections() {
+  document.getElementById('history-section-modal').classList.remove('active');
+  document.getElementById('profile-modal').classList.remove('active');
+  document.getElementById('library-modal').classList.remove('active');
+}
+
+function navHome() {
+  closeAllSections();
+  setActiveNav('home');
+}
+
+function navLibrary() {
+  closeAllSections();
+  openLibrary();
+  setActiveNav('library');
+}
+
+function navHistory() {
+  closeAllSections();
+  openHistorySection('history');
+  setActiveNav('history');
+}
+
+function navProfile() {
+  closeAllSections();
+  openProfile();
+  setActiveNav('profile');
 }
 
 // ── Player Vault ───────────────────────────────────────────────────────────
@@ -153,13 +189,11 @@ function dismissImportPrompt() {
 }
 
 function openVault() {
-  renderVaultList();
-  document.getElementById('vault-modal').classList.add('active');
-  document.getElementById('vault-name-input').focus();
+  navProfile();
 }
 
 function closeVault() {
-  document.getElementById('vault-modal').classList.remove('active');
+  closeProfile();
 }
 
 async function addToVault() {
@@ -342,12 +376,11 @@ function closeEmojiPicker() {
 
 // ── Settings ───────────────────────────────────────────────────────────────
 function openSettings() {
-  renderSettingsModal();
-  document.getElementById('settings-modal').classList.add('active');
+  navProfile();
 }
 
 function closeSettings() {
-  document.getElementById('settings-modal').classList.remove('active');
+  closeProfile();
 }
 
 function renderSettingsModal() {
@@ -590,6 +623,80 @@ function toggleSetting(key) {
 
 function applySettings() {
   document.body.classList.toggle('hide-why', !settings.showWhyBtn);
+}
+
+// ── Profile Section ─────────────────────────────────────────────────────────
+async function openProfile() {
+  renderSettingsModal();
+  renderVaultList();
+  await fetchAndRenderProfile();
+  document.getElementById('profile-modal').classList.add('active');
+  document.getElementById('vault-name-input').focus();
+}
+
+function closeProfile() {
+  document.getElementById('profile-modal').classList.remove('active');
+  setActiveNav('home');
+}
+
+async function fetchAndRenderProfile() {
+  const nameEl  = document.getElementById('profile-display-name');
+  const emailEl = document.getElementById('profile-email');
+  const avatarEl = document.getElementById('profile-avatar');
+
+  if (isDemoMode()) {
+    if (nameEl)   nameEl.textContent  = 'Demo User';
+    if (emailEl)  emailEl.textContent = '';
+    if (avatarEl) avatarEl.textContent = 'D';
+    const signout = document.getElementById('profile-signout');
+    if (signout) signout.classList.add('hidden');
+    return;
+  }
+
+  try {
+    const res = await fetch('/api/me');
+    if (!res.ok) return;
+    const { display_name, email, avatar_url } = await res.json();
+    if (nameEl)  nameEl.textContent  = display_name || email || 'User';
+    if (emailEl) emailEl.textContent = email || '';
+    if (avatarEl) {
+      if (avatar_url) {
+        avatarEl.innerHTML = `<img src="${avatar_url}" alt="${display_name || 'User'}" class="profile-avatar-img" />`;
+      } else {
+        avatarEl.textContent = (display_name || email || 'U')[0].toUpperCase();
+      }
+    }
+  } catch {}
+}
+
+// ── History Section ─────────────────────────────────────────────────────────
+function openHistorySection(tab) {
+  switchHistoryTab(tab || 'history');
+  document.getElementById('history-section-modal').classList.add('active');
+}
+
+function closeHistorySection() {
+  document.getElementById('history-section-modal').classList.remove('active');
+  setActiveNav('home');
+}
+
+function switchHistoryTab(tab) {
+  const historyPanel = document.getElementById('history-panel');
+  const statsPanel   = document.getElementById('stats-panel');
+  const tabHistory   = document.getElementById('tab-nav-history');
+  const tabStats     = document.getElementById('tab-nav-stats');
+
+  historyPanel.classList.toggle('hidden', tab !== 'history');
+  statsPanel.classList.toggle('hidden', tab !== 'stats');
+  if (tabHistory) tabHistory.classList.toggle('active', tab === 'history');
+  if (tabStats)   tabStats.classList.toggle('active',   tab === 'stats');
+
+  if (tab === 'history') {
+    renderHistory();
+  } else {
+    switchStatsTab('players');
+    renderStats();
+  }
 }
 
 // ── Filters ────────────────────────────────────────────────────────────────
@@ -1199,12 +1306,11 @@ function renderGamesInProgress() {
 
 // ── Play History ───────────────────────────────────────────────────────────
 function openHistory() {
-  renderHistory();
-  document.getElementById('history-modal').classList.add('active');
+  openHistorySection('history');
 }
 
 function closeHistory() {
-  document.getElementById('history-modal').classList.remove('active');
+  closeHistorySection();
 }
 
 function renderHistory() {
@@ -1283,13 +1389,11 @@ let activeStatsTab = 'players';
 let h2hSelected = { a: null, b: null };
 
 function openStats() {
-  switchStatsTab('players');
-  renderStats();
-  document.getElementById('stats-modal').classList.add('active');
+  openHistorySection('stats');
 }
 
 function closeStats() {
-  document.getElementById('stats-modal').classList.remove('active');
+  closeHistorySection();
 }
 
 function switchStatsTab(tab) {
@@ -1690,6 +1794,7 @@ function closeLibrary() {
   document.getElementById('library-modal').classList.remove('active');
   const form = document.getElementById('add-game-form');
   if (form) form.classList.add('hidden');
+  setActiveNav('home');
 }
 
 function setLibrarySort(key) {

--- a/index.html
+++ b/index.html
@@ -14,21 +14,21 @@
 
   <div class="container">
     <header>
-      <h1>Session Zero: A Game Night Planner</h1>
-      <p class="subtitle">So many games, so little night.</p>
-      <a href="/auth/google" id="demo-header-signin" data-testid="demo-header-signin" class="demo-header-signin hidden">Sign in with Google</a>
+      <div class="header-brand">
+        <h1>Session Zero</h1>
+        <p class="subtitle">So many games, so little night.</p>
+      </div>
+      <nav class="desktop-nav" data-testid="desktop-nav" aria-label="Main navigation">
+        <button class="nav-item active" data-nav="home" data-testid="nav-home" onclick="navHome()">Home</button>
+        <button class="nav-item" data-nav="library" data-testid="nav-library" onclick="navLibrary()">Library</button>
+        <button class="nav-item" data-nav="history" data-testid="nav-history" onclick="navHistory()">History</button>
+        <button class="nav-item" data-nav="profile" data-testid="nav-profile" onclick="navProfile()">Profile</button>
+      </nav>
     </header>
 
     <section class="roll-call">
       <div class="roll-call-header">
         <h2 class="section-label">🎲 Roll Call</h2>
-        <div class="roll-call-actions">
-          <button class="vault-btn" data-testid="btn-settings" onclick="openSettings()">⚙ Settings</button>
-          <button class="vault-btn" data-testid="btn-history" onclick="openHistory()">History</button>
-          <button class="vault-btn" data-testid="btn-stats" onclick="openStats()">Stats</button>
-          <button class="vault-btn" data-testid="btn-library" onclick="openLibrary()">My Games</button>
-          <button class="vault-btn" data-testid="btn-vault" onclick="openVault()">Player Vault</button>
-        </div>
       </div>
       <div id="roll-call-chips" data-testid="roll-call-chips" class="roll-call-chips"></div>
     </section>
@@ -165,21 +165,80 @@
     </section>
   </div>
 
-  <!-- Player Vault Modal -->
-  <div id="vault-modal" data-testid="vault-modal" class="modal-overlay">
-    <div class="modal-panel">
+  <!-- Profile Modal (Settings + Player Vault + user info) -->
+  <div id="profile-modal" data-testid="profile-modal" class="modal-overlay" onclick="closeProfile()">
+    <div class="modal-panel profile-panel" onclick="event.stopPropagation()">
       <div class="modal-header">
-        <div class="session-title">Player Vault</div>
-        <button class="modal-close" data-testid="vault-modal-close" onclick="closeVault()">×</button>
+        <div class="session-title">Profile</div>
+        <button class="modal-close" data-testid="profile-modal-close" onclick="closeProfile()">×</button>
       </div>
-      <div class="modal-section">
-        <div class="player-input-row">
-          <input type="text" id="vault-name-input" data-testid="vault-name-input"
-                 placeholder="Add a player..."
-                 onkeydown="if(event.key==='Enter') addToVault()" />
-          <button id="add-vault-btn" data-testid="vault-add-btn" onclick="addToVault()">Add</button>
+      <div class="profile-body">
+
+        <!-- User info -->
+        <div class="profile-user-info">
+          <div id="profile-avatar" data-testid="profile-avatar" class="profile-avatar"></div>
+          <div class="profile-user-text">
+            <div id="profile-display-name" data-testid="profile-display-name" class="profile-display-name"></div>
+            <div id="profile-email" data-testid="profile-email" class="profile-email"></div>
+          </div>
         </div>
-        <div id="vault-list" data-testid="vault-list" class="vault-list"></div>
+
+        <!-- Settings section -->
+        <div class="profile-section-label">Settings</div>
+        <div class="settings-body">
+          <div class="settings-group-label">BoardGameGeek</div>
+          <div class="settings-row settings-row-column">
+            <div class="settings-row-info">
+              <div class="settings-row-label">Sync Collection</div>
+              <div class="settings-row-desc">Enter your BGG username to import your owned games.</div>
+            </div>
+            <div class="bgg-username-row">
+              <input type="text" id="bgg-username-input" data-testid="bgg-username-input"
+                     class="bgg-username-input" placeholder="BGG username"
+                     onkeydown="if(event.key==='Enter')syncBGGCollection()" />
+              <button id="bgg-sync-btn" data-testid="bgg-sync-btn"
+                      class="bgg-sync-btn" onclick="syncBGGCollection()">Sync</button>
+            </div>
+            <div id="bgg-sync-status" data-testid="bgg-sync-status" class="bgg-sync-status"></div>
+          </div>
+          <div class="settings-row settings-row-column">
+            <div class="settings-row-info">
+              <div class="settings-row-label">Import from CSV</div>
+              <div class="settings-row-desc">Alternatively: on BGG go to your collection - Export - CSV.</div>
+            </div>
+            <label class="bgg-file-label" for="bgg-csv-input">Choose CSV file</label>
+            <input type="file" id="bgg-csv-input" data-testid="bgg-csv-input" accept=".csv"
+                   class="bgg-file-input" onchange="handleBGGImport(this)" />
+          </div>
+
+          <div class="settings-group-label" style="margin-top:1rem">AI Features</div>
+          <div class="settings-row">
+            <div class="settings-row-info">
+              <div class="settings-row-label">Why? Button</div>
+              <div class="settings-row-desc">Ask Claude why a game fits tonight's group</div>
+            </div>
+            <button id="setting-why-btn" data-testid="setting-why-btn" class="toggle-btn"
+                    onclick="toggleSetting('showWhyBtn')" aria-pressed="true">On</button>
+          </div>
+        </div>
+
+        <!-- Player Vault section -->
+        <div class="profile-section-label">Player Vault</div>
+        <div class="modal-section">
+          <div class="player-input-row">
+            <input type="text" id="vault-name-input" data-testid="vault-name-input"
+                   placeholder="Add a player..."
+                   onkeydown="if(event.key==='Enter') addToVault()" />
+            <button id="add-vault-btn" data-testid="vault-add-btn" onclick="addToVault()">Add</button>
+          </div>
+          <div id="vault-list" data-testid="vault-list" class="vault-list"></div>
+        </div>
+
+        <!-- Sign out -->
+        <div class="profile-signout" id="profile-signout">
+          <a href="/auth/logout" class="profile-signout-btn" data-testid="profile-signout-btn">Sign Out</a>
+        </div>
+
       </div>
     </div>
   </div>
@@ -286,89 +345,45 @@
     </div>
   </div>
 
-  <!-- Settings Modal -->
-  <div id="settings-modal" data-testid="settings-modal" class="modal-overlay" onclick="closeSettings()">
-    <div class="modal-panel settings-panel" onclick="event.stopPropagation()">
+  <!-- History Section Modal (History + Stats with tab switching) -->
+  <div id="history-section-modal" data-testid="history-section-modal" class="modal-overlay" onclick="closeHistorySection()">
+    <div class="modal-panel history-section-panel" onclick="event.stopPropagation()">
       <div class="modal-header">
-        <div class="session-title">Settings</div>
-        <button class="modal-close" data-testid="settings-modal-close" onclick="closeSettings()">×</button>
+        <div class="history-section-tabs">
+          <button class="history-section-tab active" id="tab-nav-history" data-testid="tab-nav-history"
+                  onclick="switchHistoryTab('history')">History</button>
+          <button class="history-section-tab" id="tab-nav-stats" data-testid="tab-nav-stats"
+                  onclick="switchHistoryTab('stats')">Stats</button>
+        </div>
+        <button class="modal-close" data-testid="history-section-modal-close" onclick="closeHistorySection()">×</button>
       </div>
-      <div class="settings-body">
-        <div class="settings-group-label">BoardGameGeek</div>
-        <div class="settings-row settings-row-column">
-          <div class="settings-row-info">
-            <div class="settings-row-label">Sync Collection</div>
-            <div class="settings-row-desc">Enter your BGG username to import your owned games.</div>
-          </div>
-          <div class="bgg-username-row">
-            <input type="text" id="bgg-username-input" data-testid="bgg-username-input"
-                   class="bgg-username-input" placeholder="BGG username"
-                   onkeydown="if(event.key==='Enter')syncBGGCollection()" />
-            <button id="bgg-sync-btn" data-testid="bgg-sync-btn"
-                    class="bgg-sync-btn" onclick="syncBGGCollection()">Sync</button>
-          </div>
-          <div id="bgg-sync-status" data-testid="bgg-sync-status" class="bgg-sync-status"></div>
-        </div>
-        <div class="settings-row settings-row-column">
-          <div class="settings-row-info">
-            <div class="settings-row-label">Import from CSV</div>
-            <div class="settings-row-desc">Alternatively: on BGG go to your collection → Export → CSV.</div>
-          </div>
-          <label class="bgg-file-label" for="bgg-csv-input">Choose CSV file</label>
-          <input type="file" id="bgg-csv-input" data-testid="bgg-csv-input" accept=".csv"
-                 class="bgg-file-input" onchange="handleBGGImport(this)" />
-        </div>
 
-        <div class="settings-group-label" style="margin-top:1rem">AI Features</div>
-        <div class="settings-row">
-          <div class="settings-row-info">
-            <div class="settings-row-label">Why? Button</div>
-            <div class="settings-row-desc">Ask Claude why a game fits tonight's group</div>
-          </div>
-          <button id="setting-why-btn" data-testid="setting-why-btn" class="toggle-btn"
-                  onclick="toggleSetting('showWhyBtn')" aria-pressed="true">On</button>
-        </div>
-      </div>
-    </div>
-  </div>
-
-  <!-- History Modal -->
-  <div id="history-modal" data-testid="history-modal" class="modal-overlay" onclick="closeHistory()">
-    <div class="modal-panel history-panel" onclick="event.stopPropagation()">
-      <div class="modal-header">
-        <div class="session-title">Play History</div>
-        <button class="modal-close" data-testid="history-modal-close" onclick="closeHistory()">×</button>
-      </div>
-      <div class="history-body">
+      <!-- History panel -->
+      <div id="history-panel" data-testid="history-panel" class="history-body">
         <div id="history-list" data-testid="history-list" class="history-list"></div>
       </div>
-    </div>
-  </div>
 
-  <!-- Stats Modal -->
-  <div id="stats-modal" data-testid="stats-modal" class="modal-overlay" onclick="closeStats()">
-    <div class="modal-panel stats-panel" onclick="event.stopPropagation()">
-      <div class="modal-header">
-        <div class="session-title">Player Stats</div>
-        <button class="modal-close" data-testid="stats-modal-close" onclick="closeStats()">×</button>
-      </div>
-      <div class="stats-tabs">
-        <button class="stats-tab active" id="tab-players" data-testid="tab-players"
-                onclick="switchStatsTab('players')">Players</button>
-        <button class="stats-tab" id="tab-h2h" data-testid="tab-h2h"
-                onclick="switchStatsTab('h2h')">Head-to-Head</button>
-      </div>
-      <div class="stats-body" id="stats-body-players" data-testid="stats-body-players">
-        <div id="stats-list" class="stats-list"></div>
-      </div>
-      <div class="stats-body hidden" id="stats-body-h2h" data-testid="stats-body-h2h">
-        <div class="h2h-selectors">
-          <div class="h2h-selector" id="h2h-selector-a"></div>
-          <div class="h2h-vs">vs.</div>
-          <div class="h2h-selector" id="h2h-selector-b"></div>
+      <!-- Stats panel -->
+      <div id="stats-panel" data-testid="stats-panel" class="hidden">
+        <div class="stats-tabs">
+          <button class="stats-tab active" id="tab-players" data-testid="tab-players"
+                  onclick="switchStatsTab('players')">Players</button>
+          <button class="stats-tab" id="tab-h2h" data-testid="tab-h2h"
+                  onclick="switchStatsTab('h2h')">Head-to-Head</button>
         </div>
-        <div id="h2h-result" class="h2h-result"></div>
+        <div class="stats-body" id="stats-body-players" data-testid="stats-body-players">
+          <div id="stats-list" class="stats-list"></div>
+        </div>
+        <div class="stats-body hidden" id="stats-body-h2h" data-testid="stats-body-h2h">
+          <div class="h2h-selectors">
+            <div class="h2h-selector" id="h2h-selector-a"></div>
+            <div class="h2h-vs">vs.</div>
+            <div class="h2h-selector" id="h2h-selector-b"></div>
+          </div>
+          <div id="h2h-result" class="h2h-result"></div>
+        </div>
       </div>
+
     </div>
   </div>
 
@@ -426,6 +441,26 @@
       <div id="library-list" data-testid="library-list" class="library-list"></div>
     </div>
   </div>
+
+  <!-- Mobile bottom nav -->
+  <nav class="mobile-nav" data-testid="mobile-nav" aria-label="Main navigation">
+    <button class="mobile-nav-item active" data-nav="home" data-testid="mobile-nav-home" onclick="navHome()">
+      <span class="mobile-nav-icon">🏠</span>
+      <span class="mobile-nav-label">Home</span>
+    </button>
+    <button class="mobile-nav-item" data-nav="library" data-testid="mobile-nav-library" onclick="navLibrary()">
+      <span class="mobile-nav-icon">📚</span>
+      <span class="mobile-nav-label">Library</span>
+    </button>
+    <button class="mobile-nav-item" data-nav="history" data-testid="mobile-nav-history" onclick="navHistory()">
+      <span class="mobile-nav-icon">📋</span>
+      <span class="mobile-nav-label">History</span>
+    </button>
+    <button class="mobile-nav-item" data-nav="profile" data-testid="mobile-nav-profile" onclick="navProfile()">
+      <span class="mobile-nav-icon">👤</span>
+      <span class="mobile-nav-label">Profile</span>
+    </button>
+  </nav>
 
   <script src="app.js"></script>
 </body>

--- a/routes/api.js
+++ b/routes/api.js
@@ -5,6 +5,12 @@ const pool = require("../db/index");
 const router = express.Router();
 const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
 
+// ── Me ─────────────────────────────────────────────────────────────────────
+router.get("/api/me", (req, res) => {
+  const { display_name, email, avatar_url } = req.user;
+  res.json({ display_name, email, avatar_url });
+});
+
 // ── Players ────────────────────────────────────────────────────────────────
 router.get("/api/players", async (req, res) => {
   if (!pool) return res.json([]);

--- a/routes/api.js
+++ b/routes/api.js
@@ -7,6 +7,7 @@ const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
 
 // ── Me ─────────────────────────────────────────────────────────────────────
 router.get("/api/me", (req, res) => {
+  if (!req.user) return res.status(401).json({ error: "Not authenticated" });
   const { display_name, email, avatar_url } = req.user;
   res.json({ display_name, email, avatar_url });
 });

--- a/style.css
+++ b/style.css
@@ -18,8 +18,112 @@ body {
 }
 
 header {
-  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   margin-bottom: 2rem;
+  gap: 1rem;
+}
+
+.header-brand {
+  text-align: left;
+}
+
+/* ── Desktop nav ─────────────────────────────────────────────────────────── */
+.desktop-nav {
+  display: flex;
+  gap: 0.25rem;
+  flex-shrink: 0;
+}
+
+.nav-item {
+  flex: unset;
+  padding: 0.4rem 0.85rem;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  color: #9a9ab0;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+
+.nav-item:hover {
+  color: #e0e0e0;
+  background: rgba(255, 255, 255, 0.05);
+  opacity: 1;
+}
+
+.nav-item.active {
+  color: #f5c842;
+  border-color: #f5c842;
+  background: rgba(245, 200, 66, 0.08);
+}
+
+/* ── Mobile bottom nav ───────────────────────────────────────────────────── */
+.mobile-nav {
+  display: none;
+}
+
+@media (max-width: 767px) {
+  .desktop-nav {
+    display: none;
+  }
+
+  .mobile-nav {
+    display: flex;
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background: #16213e;
+    border-top: 1px solid #0f3460;
+    z-index: 200;
+    height: 60px;
+  }
+
+  .mobile-nav-item {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.2rem;
+    background: transparent;
+    border: none;
+    color: #9a9ab0;
+    cursor: pointer;
+    min-height: 44px;
+    padding: 0.3rem 0;
+    font-family: inherit;
+    transition: color 0.15s;
+  }
+
+  .mobile-nav-item:hover {
+    color: #e0e0e0;
+    opacity: 1;
+  }
+
+  .mobile-nav-item.active {
+    color: #f5c842;
+  }
+
+  .mobile-nav-icon {
+    font-size: 1.2rem;
+    line-height: 1;
+  }
+
+  .mobile-nav-label {
+    font-size: 0.65rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  body {
+    padding-bottom: 68px;
+  }
 }
 
 h1 {
@@ -1613,23 +1717,12 @@ button:hover {
   cursor: pointer;
 }
 
-/* ── Roll Call header actions ────────────────────────────────────────────── */
-.roll-call-actions {
-  display: flex;
-  gap: 0.5rem;
-}
-
 /* ── Settings Modal ──────────────────────────────────────────────────────── */
 body.hide-why .why-btn {
   display: none !important;
 }
 
-.settings-panel {
-  max-width: 420px;
-}
-
 .settings-body {
-  padding: 1.2rem 1.5rem;
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
@@ -2008,6 +2101,137 @@ body.hide-why .why-btn {
 
 .h2h-result {
   min-height: 60px;
+}
+
+/* ── History Section Modal (combined History + Stats) ────────────────────── */
+.history-section-panel {
+  max-width: 560px;
+}
+
+.history-section-tabs {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.history-section-tab {
+  flex: unset;
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  border-radius: 0;
+  color: #9a9ab0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  padding: 0.2rem 0.5rem;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.history-section-tab:hover {
+  color: #e0e0e0;
+  opacity: 1;
+}
+
+.history-section-tab.active {
+  color: #f5c842;
+  border-bottom-color: #f5c842;
+}
+
+/* ── Profile Modal ───────────────────────────────────────────────────────── */
+.profile-panel {
+  max-width: 440px;
+}
+
+.profile-body {
+  padding: 1.2rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  overflow-y: auto;
+}
+
+.profile-user-info {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid #0f3460;
+  margin-bottom: 0.5rem;
+}
+
+.profile-avatar {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: #0f3460;
+  border: 1px solid #1a4a80;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.3rem;
+  font-weight: 700;
+  color: #f5c842;
+  flex-shrink: 0;
+  overflow: hidden;
+}
+
+.profile-avatar-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.profile-user-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.profile-display-name {
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: #e0e0e0;
+}
+
+.profile-email {
+  font-size: 0.78rem;
+  color: #6a7a90;
+}
+
+.profile-section-label {
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: #6a7a90;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-top: 0.75rem;
+  margin-bottom: 0.25rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid #0f3460;
+}
+
+.profile-signout {
+  margin-top: 1rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid #0f3460;
+}
+
+.profile-signout-btn {
+  display: inline-block;
+  padding: 0.45rem 1rem;
+  background: transparent;
+  border: 1px solid #4a5a70;
+  border-radius: 8px;
+  color: #9a9ab0;
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-decoration: none;
+  transition: border-color 0.15s, color 0.15s;
+}
+
+.profile-signout-btn:hover {
+  border-color: #e05252;
+  color: #e05252;
 }
 
 /* ── BGG Sync ────────────────────────────────────────────────────────────── */

--- a/tests/app.spec.js
+++ b/tests/app.spec.js
@@ -8,6 +8,7 @@ const { HistoryModal } = require('./pages/HistoryModal');
 const { StatsModal }   = require('./pages/StatsModal');
 const { SpotifyPanel } = require('./pages/SpotifyPanel');
 const { LandingPage }  = require('./pages/LandingPage');
+const { NavBar }       = require('./pages/NavBar');
 
 // Mock Spotify API response used across Spotify tests.
 // Two playlists so we can also test the options row when needed.
@@ -59,15 +60,14 @@ test.beforeEach(async ({ page }) => {
 });
 
 // ── Page load ──────────────────────────────────────────────────────────────
-test('loads with correct title and all header buttons', async ({ page }) => {
+test('loads with correct title and desktop nav items', async ({ page }) => {
   const main = new MainPage(page);
   await expect(page).toHaveTitle('Session Zero');
-  await expect(page.getByText('Session Zero: A Game Night Planner')).toBeVisible();
-  await expect(main.btnVault).toBeVisible();
-  await expect(main.btnLibrary).toBeVisible();
-  await expect(main.btnHistory).toBeVisible();
-  await expect(main.btnStats).toBeVisible();
-  await expect(main.btnSettings).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Session Zero' })).toBeVisible();
+  await expect(main.navHome).toBeVisible();
+  await expect(main.navLibrary).toBeVisible();
+  await expect(main.navHistory).toBeVisible();
+  await expect(main.navProfile).toBeVisible();
 });
 
 // ── Player Vault ───────────────────────────────────────────────────────────
@@ -630,7 +630,7 @@ test('demo mode shows sticky banner and sign-in button', async ({ page }) => {
   await page.waitForLoadState('networkidle');
 
   await expect(page.getByTestId('demo-banner')).toBeVisible();
-  await expect(page.getByTestId('demo-header-signin')).toBeVisible();
+  await expect(page.getByTestId('demo-banner-signin')).toBeVisible();
 });
 
 test('demo mode pre-loads four fictional players in the vault', async ({ page }) => {
@@ -705,9 +705,67 @@ test('demo mode sign-in link points to Google auth', async ({ page }) => {
   await page.goto('/demo');
   await page.waitForLoadState('networkidle');
 
-  const signinBtn = page.getByTestId('demo-header-signin');
-  await expect(signinBtn).toHaveAttribute('href', '/auth/google');
-
   const bannerSignin = page.getByTestId('demo-banner-signin');
   await expect(bannerSignin).toHaveAttribute('href', '/auth/google');
+});
+
+// ── Navigation ─────────────────────────────────────────────────────────────
+test('desktop nav shows four items at 768px and above', async ({ page }) => {
+  await page.setViewportSize({ width: 1024, height: 768 });
+  const nav = new NavBar(page);
+  await nav.expectDesktopNavVisible();
+  await expect(nav.navHome).toBeVisible();
+  await expect(nav.navLibrary).toBeVisible();
+  await expect(nav.navHistory).toBeVisible();
+  await expect(nav.navProfile).toBeVisible();
+});
+
+test('mobile nav shows four items below 768px', async ({ page }) => {
+  await page.setViewportSize({ width: 375, height: 812 });
+  const nav = new NavBar(page);
+  await nav.expectMobileNavVisible();
+  await expect(nav.mobileNavHome).toBeVisible();
+  await expect(nav.mobileNavLibrary).toBeVisible();
+  await expect(nav.mobileNavHistory).toBeVisible();
+  await expect(nav.mobileNavProfile).toBeVisible();
+});
+
+test('clicking Library nav opens the library section', async ({ page }) => {
+  const nav     = new NavBar(page);
+  const library = new LibraryModal(page);
+  await library.open();
+  await expect(library.modal).toHaveClass(/active/);
+  await nav.expectActiveNav('library');
+});
+
+test('clicking History nav opens the history section', async ({ page }) => {
+  const nav     = new NavBar(page);
+  const history = new HistoryModal(page);
+  await history.open();
+  await expect(history.modal).toHaveClass(/active/);
+  await nav.expectActiveNav('history');
+});
+
+test('clicking Profile nav opens the profile section', async ({ page }) => {
+  const nav  = new NavBar(page);
+  const vault = new VaultModal(page);
+  await vault.open();
+  await expect(vault.modal).toHaveClass(/active/);
+  await nav.expectActiveNav('profile');
+});
+
+test('Home nav closes open section and resets active state', async ({ page }) => {
+  // Mobile nav (z-index 200) is intentionally above modal overlays (z-index 100)
+  // so the Home button is always reachable even when a section is open.
+  await page.setViewportSize({ width: 375, height: 812 });
+  const nav     = new NavBar(page);
+  const history = new HistoryModal(page);
+
+  // Open history via mobile nav
+  await nav.mobileNavHistory.click();
+  await expect(history.modal).toHaveClass(/active/);
+
+  // Click Home on the mobile nav -- should close the section
+  await nav.mobileNavHome.click();
+  await expect(history.modal).not.toHaveClass(/active/);
 });

--- a/tests/pages/HistoryModal.js
+++ b/tests/pages/HistoryModal.js
@@ -3,17 +3,17 @@ const { expect } = require('@playwright/test');
 class HistoryModal {
   constructor(page) {
     this.page  = page;
-    this.modal = page.getByTestId('history-modal');
+    this.modal = page.getByTestId('history-section-modal');
     this.list  = page.getByTestId('history-list');
   }
 
   async open() {
-    await this.page.getByTestId('btn-history').click();
+    await this.page.getByTestId('nav-history').click();
     await expect(this.modal).toHaveClass(/active/);
   }
 
   async close() {
-    await this.page.getByTestId('history-modal-close').click();
+    await this.page.getByTestId('history-section-modal-close').click();
     await expect(this.modal).not.toHaveClass(/active/);
   }
 }

--- a/tests/pages/LibraryModal.js
+++ b/tests/pages/LibraryModal.js
@@ -20,7 +20,7 @@ class LibraryModal {
   }
 
   async open() {
-    await this.page.getByTestId('btn-library').click();
+    await this.page.getByTestId('nav-library').click();
     await expect(this.modal).toHaveClass(/active/);
   }
 

--- a/tests/pages/MainPage.js
+++ b/tests/pages/MainPage.js
@@ -4,12 +4,11 @@ class MainPage {
   constructor(page) {
     this.page = page;
 
-    // Header nav buttons
-    this.btnSettings = page.getByTestId('btn-settings');
-    this.btnHistory  = page.getByTestId('btn-history');
-    this.btnStats    = page.getByTestId('btn-stats');
-    this.btnLibrary  = page.getByTestId('btn-library');
-    this.btnVault    = page.getByTestId('btn-vault');
+    // Desktop nav items
+    this.navHome    = page.getByTestId('nav-home');
+    this.navLibrary = page.getByTestId('nav-library');
+    this.navHistory = page.getByTestId('nav-history');
+    this.navProfile = page.getByTestId('nav-profile');
 
     // Roll call
     this.rollCallChips = page.getByTestId('roll-call-chips');

--- a/tests/pages/NavBar.js
+++ b/tests/pages/NavBar.js
@@ -1,0 +1,38 @@
+const { expect } = require('@playwright/test');
+
+class NavBar {
+  constructor(page) {
+    this.page = page;
+
+    // Desktop nav (768px and above)
+    this.desktopNav    = page.getByTestId('desktop-nav');
+    this.navHome       = page.getByTestId('nav-home');
+    this.navLibrary    = page.getByTestId('nav-library');
+    this.navHistory    = page.getByTestId('nav-history');
+    this.navProfile    = page.getByTestId('nav-profile');
+
+    // Mobile nav (below 768px)
+    this.mobileNav         = page.getByTestId('mobile-nav');
+    this.mobileNavHome     = page.getByTestId('mobile-nav-home');
+    this.mobileNavLibrary  = page.getByTestId('mobile-nav-library');
+    this.mobileNavHistory  = page.getByTestId('mobile-nav-history');
+    this.mobileNavProfile  = page.getByTestId('mobile-nav-profile');
+  }
+
+  async expectDesktopNavVisible() {
+    await expect(this.desktopNav).toBeVisible();
+    await expect(this.mobileNav).not.toBeVisible();
+  }
+
+  async expectMobileNavVisible() {
+    await expect(this.mobileNav).toBeVisible();
+    await expect(this.desktopNav).not.toBeVisible();
+  }
+
+  async expectActiveNav(name) {
+    const item = this.page.getByTestId(`nav-${name}`);
+    await expect(item).toHaveClass(/active/);
+  }
+}
+
+module.exports = { NavBar };

--- a/tests/pages/SettingsModal.js
+++ b/tests/pages/SettingsModal.js
@@ -3,7 +3,7 @@ const { expect } = require('@playwright/test');
 class SettingsModal {
   constructor(page) {
     this.page        = page;
-    this.modal       = page.getByTestId('settings-modal');
+    this.modal       = page.getByTestId('profile-modal');
     this.whyBtn      = page.getByTestId('setting-why-btn');
     this.syncStatus  = page.getByTestId('bgg-sync-status');
     this.usernameInput = page.getByTestId('bgg-username-input');
@@ -11,12 +11,12 @@ class SettingsModal {
   }
 
   async open() {
-    await this.page.getByTestId('btn-settings').click();
+    await this.page.getByTestId('nav-profile').click();
     await expect(this.modal).toHaveClass(/active/);
   }
 
   async close() {
-    await this.page.getByTestId('settings-modal-close').click();
+    await this.page.getByTestId('profile-modal-close').click();
     await expect(this.modal).not.toHaveClass(/active/);
   }
 
@@ -32,7 +32,7 @@ class SettingsModal {
     await expect(this.whyBtn).toHaveText('Off');
   }
 
-  // Sets up a page.route() mock for /api/bgg/collection, opens Settings,
+  // Sets up a page.route() mock for /api/bgg/collection, opens Profile,
   // fills in a username, and clicks Sync. routeHandler receives the Playwright
   // Route object so callers can fulfill, abort, or return custom responses.
   async mockAndSync(routeHandler, username = 'testuser') {

--- a/tests/pages/StatsModal.js
+++ b/tests/pages/StatsModal.js
@@ -3,7 +3,7 @@ const { expect } = require('@playwright/test');
 class StatsModal {
   constructor(page) {
     this.page          = page;
-    this.modal         = page.getByTestId('stats-modal');
+    this.modal         = page.getByTestId('history-section-modal');
     this.tabPlayers    = page.getByTestId('tab-players');
     this.tabH2H        = page.getByTestId('tab-h2h');
     this.bodyPlayers   = page.getByTestId('stats-body-players');
@@ -11,12 +11,13 @@ class StatsModal {
   }
 
   async open() {
-    await this.page.getByTestId('btn-stats').click();
+    await this.page.getByTestId('nav-history').click();
+    await this.page.getByTestId('tab-nav-stats').click();
     await expect(this.modal).toHaveClass(/active/);
   }
 
   async close() {
-    await this.page.getByTestId('stats-modal-close').click();
+    await this.page.getByTestId('history-section-modal-close').click();
     await expect(this.modal).not.toHaveClass(/active/);
   }
 

--- a/tests/pages/VaultModal.js
+++ b/tests/pages/VaultModal.js
@@ -3,19 +3,19 @@ const { expect } = require('@playwright/test');
 class VaultModal {
   constructor(page) {
     this.page      = page;
-    this.modal     = page.getByTestId('vault-modal');
+    this.modal     = page.getByTestId('profile-modal');
     this.nameInput = page.getByTestId('vault-name-input');
     this.addBtn    = page.getByTestId('vault-add-btn');
     this.list      = page.getByTestId('vault-list');
   }
 
   async open() {
-    await this.page.getByTestId('btn-vault').click();
+    await this.page.getByTestId('nav-profile').click();
     await expect(this.modal).toHaveClass(/active/);
   }
 
   async close() {
-    await this.page.getByTestId('vault-modal-close').click();
+    await this.page.getByTestId('profile-modal-close').click();
     await expect(this.modal).not.toHaveClass(/active/);
   }
 


### PR DESCRIPTION
## Summary

- Replaces five utility buttons in the Roll Call header with a proper responsive nav bar
- Desktop (768px+): four items in the top header bar (Home, Library, History, Profile)
- Mobile (<768px): four items in a fixed bottom nav bar with icons and labels, 44px tap targets
- History destination: combines Play History and Player Stats into one modal with tab switching
- Profile destination: combines Settings and Player Vault into one scrollable panel with user info and Sign Out
- Library destination: existing My Games modal, now opened via the Library nav item
- Home nav item: always active when no section is open; clicking it closes any open section
- Adds `GET /api/me` endpoint returning `{ display_name, email, avatar_url }` for the auth'd user
- Demo mode: Profile section shows "Demo User" with no email, sign-out button is hidden
- All 40 existing tests updated and passing; 6 new nav tests added (46 total)

## Commits

1. HTML structure: nav elements, merged modals
2. CSS: desktop nav, mobile nav, profile panel, history section panel styles
3. JS + API: nav functions, `/api/me` endpoint, composite section open/close logic
4. Page Objects: updated open() methods to use new nav testids
5. Tests: updated 3 tests reflecting removed elements, added 6 new nav tests

## Test plan

- [x] 46 Playwright tests pass
- [x] Desktop nav visible at 1024px viewport, mobile nav hidden
- [x] Mobile nav visible at 375px viewport, desktop nav hidden
- [x] Library nav opens My Games modal
- [x] History nav opens combined History+Stats section defaulting to History tab
- [x] Profile nav opens scrollable Profile panel with Settings, Player Vault, Sign Out
- [x] Home nav closes open sections
- [x] Demo mode works with demo-banner sign-in link preserved

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)