### PR TITLE
Add project diary and diary/reflect slash commands

### DIFF
--- a/.claude/commands/diary.md
+++ b/.claude/commands/diary.md
@@ -1,0 +1,25 @@
+# /diary
+Append a new entry to docs/diary.md for today's session.
+
+Entry format:
+
+## [Today's date]
+
+### Completed
+List issues closed, PRs merged, features shipped.
+
+### Decisions made
+Any architectural, design, or process decisions made this session.
+
+### In progress
+What is currently open - branches, PRs, partial work.
+
+### Up next
+What should be tackled next session.
+
+### Notes
+Anything worth remembering - bugs found, gotchas, context that would help next session.
+
+---
+
+Write the entry based on what actually happened this session. Be specific - issue numbers, PR numbers, file names. Not vague summaries.

--- a/.claude/commands/reflect.md
+++ b/.claude/commands/reflect.md
@@ -1,0 +1,10 @@
+# /reflect
+Read docs/diary.md and orient for this session.
+
+Output:
+- One paragraph summary of the last 3 diary entries
+- What is currently in progress (open PRs, started issues)
+- What was planned as up next in the most recent entry
+- Any notes or gotchas flagged in recent entries
+
+Keep it concise - this is a session startup briefing, not a full recap.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,3 +200,4 @@ Define success criteria. Loop until verified.
 - Use /plan before any implementation -- never skip the plan step
 - Use /issue to create GitHub Issues -- keeps prompt library in sync
 - Use /review before merging any PR
+- docs/diary.md is the project diary -- run /reflect at the start of each session and /diary at the end

--- a/docs/diary.md
+++ b/docs/diary.md
@@ -1,0 +1,6 @@
+# Session Zero - Project Diary
+
+A running log of work sessions. Updated at the end of every session using /diary.
+Read at the start of every session using /reflect.
+
+---


### PR DESCRIPTION
## Summary

- Adds `docs/diary.md` as a running session log (initially empty, ready for first entry)
- Adds `/diary` slash command: appends a dated entry with Completed, Decisions made, In progress, Up next, and Notes sections
- Adds `/reflect` slash command: reads the last 3 entries and outputs a concise session startup briefing
- Updates `CLAUDE.md` Working Approach to reference the diary workflow

## Test plan

- [ ] Run `/diary` at end of a session - verify a dated entry is appended to `docs/diary.md`
- [ ] Run `/reflect` at start of a session - verify it summarizes recent entries and surfaces in-progress work
- [ ] Confirm `CLAUDE.md` Working Approach section contains the diary reference line

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)