### PR TITLE
Fix modal scroll and mobile nav overlap

### DIFF
--- a/style.css
+++ b/style.css
@@ -124,6 +124,10 @@ header {
   body {
     padding-bottom: 68px;
   }
+
+  .modal-overlay {
+    padding-bottom: 60px;
+  }
 }
 
 h1 {
@@ -2106,6 +2110,9 @@ body.hide-why .why-btn {
 /* ── History Section Modal (combined History + Stats) ────────────────────── */
 .history-section-panel {
   max-width: 560px;
+  height: auto;
+  max-height: 90vh;
+  overflow-y: auto;
 }
 
 .history-section-tabs {
@@ -2140,6 +2147,10 @@ body.hide-why .why-btn {
 /* ── Profile Modal ───────────────────────────────────────────────────────── */
 .profile-panel {
   max-width: 440px;
+  /* Override the session-modal desktop rule that locks height and hides overflow */
+  height: auto;
+  max-height: 90vh;
+  overflow-y: auto;
 }
 
 .profile-body {
@@ -2147,7 +2158,6 @@ body.hide-why .why-btn {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  overflow-y: auto;
 }
 
 .profile-user-info {


### PR DESCRIPTION
## Summary
- `.modal-overlay` on mobile was missing `padding-bottom: 60px`, so content at the bottom of any modal was hidden behind the fixed nav bar
- `history-section-panel` and `profile-panel` were inheriting a session-modal desktop rule that locked `height` and hid `overflow`, causing content to clip rather than scroll
- Moved `overflow-y: auto` from `.profile-body` to `.profile-panel` so the scroll container is at the correct level

All three issues are follow-up polish from the nav restructure in #117 (closes #116).

## Test plan
- [ ] Open History modal on mobile - confirm content scrolls and is not hidden behind the nav bar
- [ ] Open Profile modal on mobile and desktop - confirm it scrolls when content exceeds viewport height
- [ ] Open any modal on mobile - confirm the bottom is not obscured by the nav bar
- [ ] Run `npx playwright test` - all existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)