### PR TITLE
Fix BGG badge linking to Google search instead of BoardGameGeek

### DIFF
--- a/app.js
+++ b/app.js
@@ -533,10 +533,16 @@ function handleBGGImport(input) {
 function mergeBGGGames(local, incoming) {
   const BGG_FIELDS = ['name', 'thumbnail', 'minPlayers', 'maxPlayers', 'playTime', 'complexity', 'type'];
   const incomingMap = new Map(incoming.map(g => [g.bggId, g]));
+  const incomingByName = new Map(incoming.map(g => [g.name.trim().toLowerCase(), g]));
   const seenIds = new Set();
 
   const merged = local.map(localGame => {
-    if (!localGame.bggId) return localGame; // manual - never touch
+    if (!localGame.bggId) {
+      const nameMatch = incomingByName.get(localGame.name.trim().toLowerCase());
+      if (!nameMatch) return localGame;
+      seenIds.add(nameMatch.bggId);
+      return { ...localGame, bggId: nameMatch.bggId, source: 'bgg' };
+    }
     const remote = incomingMap.get(localGame.bggId);
     if (!remote) return localGame; // no longer in BGG response - preserve as-is
     seenIds.add(localGame.bggId);

--- a/tests/app.spec.js
+++ b/tests/app.spec.js
@@ -437,6 +437,40 @@ test('BGG sync adds new games from BGG not yet in the local library', async ({ p
   await library.expectGame('Brand New Game');
 });
 
+test('BGG sync backfills bggId on a name-matched manual game so badge links to BGG', async ({ page }) => {
+  const settings = new SettingsModal(page);
+  const main     = new MainPage(page);
+
+  await page.evaluate(() => {
+    localStorage.setItem('sz-games', JSON.stringify([
+      { name: 'Ticket to Ride', minPlayers: 2, maxPlayers: 5, playTime: 60,
+        complexity: 'Low', type: 'Board', age: 8, setupTime: 10, rating: 4,
+        played: false, cooperative: false, thumbnail: null, bggId: null, source: 'manual' },
+    ]));
+  });
+  await page.reload();
+
+  await settings.mockAndSync(route =>
+    route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({
+        games: [{ name: 'Ticket to Ride', minPlayers: 2, maxPlayers: 5, playTime: 60,
+                  complexity: 'Low', type: 'Board', age: 8, setupTime: 10,
+                  rating: null, played: false, cooperative: false, thumbnail: null, bggId: 9209 }],
+        count: 1,
+      }),
+    })
+  );
+
+  await settings.expectSyncSuccess('Synced 1');
+  await settings.close();
+  await main.findGames();
+  await main.expandGameCard(0);
+
+  const badge = main.gameCards().nth(0).getByTestId('bgg-badge');
+  await expect(badge).toHaveAttribute('href', 'https://boardgamegeek.com/boardgame/9209');
+});
+
 test('BGG sync shows error message on server failure', async ({ page }) => {
   const settings = new SettingsModal(page);
 


### PR DESCRIPTION
## Summary
- `mergeBGGGames` was treating every game without a `bggId` as untouchable manual data, so games loaded from `games.json` (which has no `bggId` fields) could never acquire one through a BGG sync
- Added a secondary name-based lookup (case-insensitive, trimmed) as a fallback when a local game has no `bggId`; on a match, `bggId` is backfilled and `source` set to `'bgg'`
- After the next BGG sync, those games correctly link to `boardgamegeek.com/boardgame/{bggId}` instead of falling back to Google search

## Test plan
- [ ] New test: `BGG sync backfills bggId on a name-matched manual game so badge links to BGG` - seeds a manual game with no bggId, mocks a sync response with the same name and a real bggId, asserts badge href points to boardgamegeek.com
- [ ] All 47 existing tests still pass
- [ ] No changes to Page Objects or test selectors

Closes #124