### PR TITLE
Migrate settings from localStorage to Postgres

### DIFF
--- a/app.js
+++ b/app.js
@@ -47,7 +47,7 @@ let currentSpotifyOptions = [];   // full list returned by last fetch
 
 // Settings
 const SETTINGS_DEFAULTS = { showWhyBtn: true };
-let settings = { ...SETTINGS_DEFAULTS, ...(isDemoMode() ? {} : JSON.parse(localStorage.getItem('sz-settings') || '{}')) };
+let settings = { ...SETTINGS_DEFAULTS };
 
 // ── Init ───────────────────────────────────────────────────────────────────
 function migrateGameSources(arr) {
@@ -102,6 +102,7 @@ renderGamesInProgress();
 applySettings();
 if (!isDemoMode()) {
   initVault();
+  initSettings();
 }
 
 // ── Navigation ─────────────────────────────────────────────────────────────
@@ -155,6 +156,27 @@ async function initVault() {
   }
   renderRollCall();
   checkLocalStorageImport();
+}
+
+async function initSettings() {
+  try {
+    const res = await fetch('/api/settings');
+    if (!res.ok) return;
+    Object.assign(settings, await res.json());
+  } catch {
+    // Network error - keep defaults
+  }
+  applySettings();
+  renderSettingsModal();
+}
+
+function saveSettings() {
+  if (isDemoMode()) return;
+  fetch('/api/settings', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(settings),
+  }).catch(() => {});
 }
 
 function checkLocalStorageImport() {
@@ -513,7 +535,7 @@ function handleBGGImport(input) {
         month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit',
       });
       settings.bggLastSyncCount = imported.length;
-      if (!isDemoMode()) localStorage.setItem('sz-settings', JSON.stringify(settings));
+      saveSettings();
 
       statusEl.textContent = `Synced ${imported.length} games from BoardGameGeek at ${settings.bggLastSync}.`;
       statusEl.className = 'bgg-sync-status bgg-sync-ok';
@@ -573,7 +595,7 @@ async function syncBGGCollection() {
 
   // Save username for next time
   settings.bggUsername = username;
-  if (!isDemoMode()) localStorage.setItem('sz-settings', JSON.stringify(settings));
+  saveSettings();
 
   btn.disabled = true;
   btn.textContent = 'Syncing…';
@@ -603,7 +625,7 @@ async function syncBGGCollection() {
       month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit',
     });
     settings.bggLastSyncCount = data.count;
-    if (!isDemoMode()) localStorage.setItem('sz-settings', JSON.stringify(settings));
+    saveSettings();
 
     statusEl.textContent = `Synced ${data.count} games from BoardGameGeek at ${settings.bggLastSync}.`;
     statusEl.className = 'bgg-sync-status bgg-sync-ok';
@@ -622,7 +644,7 @@ async function syncBGGCollection() {
 
 function toggleSetting(key) {
   settings[key] = !settings[key];
-  if (!isDemoMode()) localStorage.setItem('sz-settings', JSON.stringify(settings));
+  saveSettings();
   applySettings();
   renderSettingsModal();
 }

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -24,3 +24,11 @@ CREATE TABLE IF NOT EXISTS session (
 );
 
 CREATE INDEX IF NOT EXISTS session_expire_idx ON session (expire);
+
+CREATE TABLE IF NOT EXISTS settings (
+  user_id             INTEGER PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+  show_why_btn        BOOLEAN DEFAULT TRUE,
+  bgg_username        TEXT,
+  bgg_last_sync       TEXT,
+  bgg_last_sync_count INTEGER
+);

--- a/routes/api.js
+++ b/routes/api.js
@@ -80,6 +80,54 @@ router.delete("/api/players/:id", async (req, res) => {
   }
 });
 
+// ── Settings ───────────────────────────────────────────────────────────────
+function normalizeSettings(row) {
+  return {
+    showWhyBtn:       row.show_why_btn,
+    bggUsername:      row.bgg_username,
+    bggLastSync:      row.bgg_last_sync,
+    bggLastSyncCount: row.bgg_last_sync_count,
+  };
+}
+
+router.get("/api/settings", async (req, res) => {
+  if (!pool) return res.json(normalizeSettings({ show_why_btn: true, bgg_username: null, bgg_last_sync: null, bgg_last_sync_count: null }));
+  try {
+    const { rows } = await pool.query(
+      `INSERT INTO settings (user_id) VALUES ($1)
+       ON CONFLICT (user_id) DO UPDATE SET user_id = EXCLUDED.user_id
+       RETURNING *`,
+      [req.user.id]
+    );
+    res.json(normalizeSettings(rows[0]));
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+router.put("/api/settings", async (req, res) => {
+  if (!pool) return res.status(503).json({ error: "Database not available" });
+  try {
+    const { showWhyBtn, bggUsername, bggLastSync, bggLastSyncCount } = req.body;
+    const { rows } = await pool.query(
+      `INSERT INTO settings (user_id, show_why_btn, bgg_username, bgg_last_sync, bgg_last_sync_count)
+       VALUES ($1, $2, $3, $4, $5)
+       ON CONFLICT (user_id) DO UPDATE SET
+         show_why_btn        = EXCLUDED.show_why_btn,
+         bgg_username        = EXCLUDED.bgg_username,
+         bgg_last_sync       = EXCLUDED.bgg_last_sync,
+         bgg_last_sync_count = EXCLUDED.bgg_last_sync_count
+       RETURNING *`,
+      [req.user.id, showWhyBtn ?? true, bggUsername ?? null, bggLastSync ?? null, bggLastSyncCount ?? null]
+    );
+    res.json(normalizeSettings(rows[0]));
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: err.message });
+  }
+});
+
 // ── Spotify ────────────────────────────────────────────────────────────────
 let spotifyToken = null;
 let spotifyTokenExpiry = 0;

--- a/tests/app.spec.js
+++ b/tests/app.spec.js
@@ -351,6 +351,46 @@ test('settings modal opens and Why? toggle works', async ({ page }) => {
   await expect(page.getByTestId('why-btn').first()).toBeHidden();
 });
 
+test('Why? toggle setting persists across page reload', async ({ page }) => {
+  const settings = new SettingsModal(page);
+  const main     = new MainPage(page);
+
+  let savedShowWhyBtn = true;
+
+  // Mock GET to return current value; mock PUT to capture what was saved
+  await settings.mockSettings(async route => {
+    if (route.request().method() === 'PUT') {
+      const body = route.request().postDataJSON();
+      savedShowWhyBtn = body.showWhyBtn;
+      return route.fulfill({ contentType: 'application/json', body: JSON.stringify(body) });
+    }
+    return route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({ showWhyBtn: savedShowWhyBtn, bggUsername: null, bggLastSync: null, bggLastSyncCount: null }),
+    });
+  });
+
+  await page.reload();
+  await settings.open();
+  await settings.expectWhyBtnOn();
+
+  await settings.toggleWhyBtn();
+  await settings.expectWhyBtnOff();
+  await settings.close();
+
+  expect(savedShowWhyBtn).toBe(false);
+
+  // Reload - mock now returns the saved value of false
+  await page.reload();
+  await settings.open();
+  await settings.expectWhyBtnOff();
+
+  // Game cards should still hide the Why? button after reload
+  await settings.close();
+  await main.findGames();
+  await expect(page.getByTestId('why-btn').first()).toBeHidden();
+});
+
 // ── BGG Sync (merge behavior) ──────────────────────────────────────────────
 // All tests mock /api/bgg/collection via page.route() - no live BGG API calls.
 

--- a/tests/pages/SettingsModal.js
+++ b/tests/pages/SettingsModal.js
@@ -32,6 +32,10 @@ class SettingsModal {
     await expect(this.whyBtn).toHaveText('Off');
   }
 
+  async mockSettings(routeHandler) {
+    await this.page.route('/api/settings*', routeHandler);
+  }
+
   // Sets up a page.route() mock for /api/bgg/collection, opens Profile,
   // fills in a username, and clicks Sync. routeHandler receives the Playwright
   // Route object so callers can fulfill, abort, or return custom responses.


### PR DESCRIPTION
## Summary
- Adds a `settings` table (one row per user) with columns for `show_why_btn`, `bgg_username`, `bgg_last_sync`, `bgg_last_sync_count`
- `GET /api/settings` returns the user's settings, creating a defaults row on first access
- `PUT /api/settings` upserts all settings fields in one call
- `initSettings()` in `app.js` fetches settings on page load and merges into the in-memory `settings` object; fails gracefully if unauthenticated or DB unavailable
- `saveSettings()` replaces all four `localStorage.setItem('sz-settings', ...)` call sites with a fire-and-forget `PUT /api/settings`; in-memory object remains source of truth for UI
- Demo mode untouched - all `isDemoMode()` guards preserved

## Test plan
- [ ] New test: `Why? toggle setting persists across page reload` - mocks GET/PUT, toggles off, reloads with mocked value of false, asserts toggle still shows Off and Why? buttons are hidden
- [ ] All 48 tests pass (including all pre-existing settings and BGG sync tests)
- [ ] `mockSettings(handler)` added to `SettingsModal` Page Object

Closes #109