### PR TITLE
Migrate game library from localStorage to Postgres

### DIFF
--- a/app.js
+++ b/app.js
@@ -50,18 +50,6 @@ const SETTINGS_DEFAULTS = { showWhyBtn: true };
 let settings = { ...SETTINGS_DEFAULTS };
 
 // ── Init ───────────────────────────────────────────────────────────────────
-function migrateGameSources(arr) {
-  let dirty = false;
-  for (const g of arr) {
-    if (!g.source) {
-      g.source = g.bggId ? 'bgg' : 'manual';
-      dirty = true;
-    }
-  }
-  if (dirty && !isDemoMode()) localStorage.setItem('sz-games', JSON.stringify(arr));
-  return arr;
-}
-
 if (isDemoMode()) {
   fetch("demo-games.json")
     .then(res => res.json())
@@ -83,18 +71,6 @@ if (isDemoMode()) {
   // Show demo UI
   document.getElementById('demo-banner').classList.remove('hidden');
   document.getElementById('demo-header-signin')?.classList.remove('hidden');
-} else {
-  const storedGames = localStorage.getItem('sz-games');
-  if (storedGames) {
-    games = migrateGameSources(JSON.parse(storedGames));
-  } else {
-    fetch("games.json")
-      .then(res => res.json())
-      .then(data => {
-        games = data.map(g => ({ ...g, source: g.bggId ? 'bgg' : 'manual' }));
-      })
-      .catch(() => console.error("Could not load games.json"));
-  }
 }
 
 renderRollCall();
@@ -103,6 +79,7 @@ applySettings();
 if (!isDemoMode()) {
   initVault();
   initSettings();
+  initGames();
 }
 
 // ── Navigation ─────────────────────────────────────────────────────────────
@@ -177,6 +154,45 @@ function saveSettings() {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(settings),
   }).catch(() => {});
+}
+
+async function initGames() {
+  try {
+    const res = await fetch('/api/games');
+    if (!res.ok) return;
+    games = await res.json();
+  } catch {
+    // Network error - games stays empty
+  }
+  checkGamesLocalStorageImport();
+}
+
+function checkGamesLocalStorageImport() {
+  if (games.length > 0) return;
+  const legacy = localStorage.getItem('sz-games');
+  if (!legacy) return;
+  document.getElementById('games-import-prompt')?.classList.remove('hidden');
+}
+
+async function importLocalGames() {
+  const legacy = JSON.parse(localStorage.getItem('sz-games') || '[]');
+  if (legacy.length === 0) { dismissGamesImportPrompt(); return; }
+  try {
+    const res = await fetch('/api/games/sync', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(legacy),
+    });
+    if (res.ok) games = await res.json();
+  } catch {}
+  localStorage.removeItem('sz-games');
+  document.getElementById('games-import-prompt')?.classList.add('hidden');
+  renderLibrary();
+}
+
+function dismissGamesImportPrompt() {
+  localStorage.removeItem('sz-games');
+  document.getElementById('games-import-prompt')?.classList.add('hidden');
 }
 
 function checkLocalStorageImport() {
@@ -420,7 +436,7 @@ function renderSettingsModal() {
 
   const statusEl = document.getElementById('bgg-sync-status');
   if (statusEl && settings.bggLastSync) {
-    const count = settings.bggLastSyncCount ?? JSON.parse(localStorage.getItem('sz-games') || '[]').length;
+    const count = settings.bggLastSyncCount ?? games.length;
     statusEl.textContent = `Synced ${count} games from BoardGameGeek at ${settings.bggLastSync}.`;
     statusEl.className = 'bgg-sync-status bgg-sync-ok';
   }
@@ -529,7 +545,15 @@ function handleBGGImport(input) {
         return;
       }
       games = imported;
-      if (!isDemoMode()) localStorage.setItem('sz-games', JSON.stringify(games));
+      if (!isDemoMode()) {
+        fetch('/api/games/sync', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(games),
+        }).then(res => res.ok ? res.json() : null).then(synced => {
+          if (synced) games = synced;
+        }).catch(() => {});
+      }
 
       settings.bggLastSync = new Date().toLocaleString('en-US', {
         month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit',
@@ -619,7 +643,15 @@ async function syncBGGCollection() {
     }
 
     games = mergeBGGGames(games, data.games);
-    if (!isDemoMode()) localStorage.setItem('sz-games', JSON.stringify(games));
+    if (!isDemoMode()) {
+      fetch('/api/games/sync', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(games),
+      }).then(res => res.ok ? res.json() : null).then(synced => {
+        if (synced) games = synced;
+      }).catch(() => {});
+    }
 
     settings.bggLastSync = new Date().toLocaleString('en-US', {
       month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit',
@@ -1048,7 +1080,16 @@ function saveSpotifyPlaylist() {
   if (idx >= 0) {
     games[idx].spotifyEmbedUrl = currentSpotifyData.embedUrl;
     games[idx].spotifyPlaylistName = currentSpotifyData.name;
-    if (!isDemoMode()) localStorage.setItem('sz-games', JSON.stringify(games));
+    if (!isDemoMode() && games[idx].id) {
+      fetch(`/api/games/${games[idx].id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          spotifyEmbedUrl: currentSpotifyData.embedUrl,
+          spotifyPlaylistName: currentSpotifyData.name,
+        }),
+      }).catch(() => {});
+    }
     sessionGame = games[idx];
   }
   const btn = document.querySelector('.spotify-save-btn');
@@ -1912,17 +1953,21 @@ function renderLibrary() {
   }).join('');
 }
 
-function saveGames() {
-  if (isDemoMode()) return;
-  localStorage.setItem('sz-games', JSON.stringify(games));
+function gamePut(game, fields) {
+  if (isDemoMode() || !game.id) return;
+  fetch(`/api/games/${game.id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(fields),
+  }).catch(() => {});
 }
 
 function setGameRating(displayIdx, n) {
   const { game, idx } = libraryDisplayed[displayIdx];
   // clicking the same star again clears the rating
   games[idx].rating = game.rating === n ? null : n;
-  saveGames();
   renderLibrary();
+  gamePut(game, { rating: games[idx].rating });
 }
 
 function cycleGameField(displayIdx, field) {
@@ -1934,23 +1979,25 @@ function cycleGameField(displayIdx, field) {
     const i = GAME_COMPLEXITIES.indexOf(game.complexity);
     games[idx].complexity = GAME_COMPLEXITIES[(i + 1) % GAME_COMPLEXITIES.length];
   }
-  saveGames();
   renderLibrary();
+  gamePut(game, { [field]: games[idx][field] });
 }
 
 function toggleGameField(displayIdx, field) {
-  const { idx } = libraryDisplayed[displayIdx];
+  const { game, idx } = libraryDisplayed[displayIdx];
   games[idx][field] = !games[idx][field];
-  saveGames();
   renderLibrary();
+  gamePut(game, { [field]: games[idx][field] });
 }
 
 function deleteGame(displayIdx) {
   const { game, idx } = libraryDisplayed[displayIdx];
   if (!confirm(`Remove "${game.name}" from your library?`)) return;
   games.splice(idx, 1);
-  saveGames();
   renderLibrary();
+  if (!isDemoMode() && game.id) {
+    fetch(`/api/games/${game.id}`, { method: 'DELETE' }).catch(() => {});
+  }
 }
 
 function toggleAddGameForm() {
@@ -1972,7 +2019,7 @@ function submitAddGame() {
   }
   const minPlayers = parseInt(document.getElementById('ag-min-players')?.value) || 2;
   const maxPlayers = parseInt(document.getElementById('ag-max-players')?.value) || minPlayers;
-  games.push({
+  const newGame = {
     name,
     type:       document.getElementById('ag-type')?.value || 'Board',
     complexity: document.getElementById('ag-complexity')?.value || 'Medium',
@@ -1987,8 +2034,17 @@ function submitAddGame() {
     thumbnail:  null,
     bggId:      null,
     source:     'manual',
-  });
-  saveGames();
+  };
+  games.push(newGame);
+  if (!isDemoMode()) {
+    fetch('/api/games', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(newGame),
+    }).then(res => res.ok ? res.json() : null).then(saved => {
+      if (saved) newGame.id = saved.id;
+    }).catch(() => {});
+  }
   // reset form
   ['ag-name','ag-min-players','ag-max-players','ag-playtime','ag-age'].forEach(id => {
     const el = document.getElementById(id); if (el) el.value = '';

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -25,6 +25,28 @@ CREATE TABLE IF NOT EXISTS session (
 
 CREATE INDEX IF NOT EXISTS session_expire_idx ON session (expire);
 
+CREATE TABLE IF NOT EXISTS games (
+  id                    SERIAL PRIMARY KEY,
+  user_id               INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  name                  TEXT NOT NULL,
+  type                  TEXT DEFAULT 'Board',
+  complexity            TEXT DEFAULT 'Medium',
+  min_players           INTEGER DEFAULT 1,
+  max_players           INTEGER DEFAULT 4,
+  play_time             INTEGER DEFAULT 60,
+  age                   INTEGER DEFAULT 0,
+  setup_time            INTEGER DEFAULT 10,
+  rating                INTEGER,
+  played                BOOLEAN DEFAULT FALSE,
+  cooperative           BOOLEAN DEFAULT FALSE,
+  thumbnail             TEXT,
+  bgg_id                INTEGER,
+  source                TEXT DEFAULT 'manual',
+  spotify_embed_url     TEXT,
+  spotify_playlist_name TEXT,
+  created_at            TIMESTAMPTZ DEFAULT NOW()
+);
+
 CREATE TABLE IF NOT EXISTS settings (
   user_id             INTEGER PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
   show_why_btn        BOOLEAN DEFAULT TRUE,

--- a/index.html
+++ b/index.html
@@ -39,6 +39,12 @@
       <button onclick="dismissImportPrompt()" data-testid="vault-import-no">No thanks</button>
     </div>
 
+    <div id="games-import-prompt" data-testid="games-import-prompt" class="vault-import-prompt hidden">
+      <span>We found games on this device. Import them to your account?</span>
+      <button onclick="importLocalGames()" data-testid="games-import-yes">Import</button>
+      <button onclick="dismissGamesImportPrompt()" data-testid="games-import-no">No thanks</button>
+    </div>
+
     <section class="games-in-progress hidden" id="games-in-progress">
       <h2 class="section-label">Games in Progress</h2>
       <div id="gip-list" class="gip-list"></div>

--- a/routes/api.js
+++ b/routes/api.js
@@ -128,6 +128,133 @@ router.put("/api/settings", async (req, res) => {
   }
 });
 
+// ── Games ──────────────────────────────────────────────────────────────────
+function normalizeGame(row) {
+  return {
+    id:                  row.id,
+    name:                row.name,
+    type:                row.type,
+    complexity:          row.complexity,
+    minPlayers:          row.min_players,
+    maxPlayers:          row.max_players,
+    playTime:            row.play_time,
+    age:                 row.age,
+    setupTime:           row.setup_time,
+    rating:              row.rating,
+    played:              row.played,
+    cooperative:         row.cooperative,
+    thumbnail:           row.thumbnail,
+    bggId:               row.bgg_id,
+    source:              row.source,
+    spotifyEmbedUrl:     row.spotify_embed_url,
+    spotifyPlaylistName: row.spotify_playlist_name,
+  };
+}
+
+const GAME_INSERT_COLS = `(user_id, name, type, complexity, min_players, max_players,
+  play_time, age, setup_time, rating, played, cooperative, thumbnail, bgg_id, source,
+  spotify_embed_url, spotify_playlist_name)`;
+const GAME_INSERT_VALS = `($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17)`;
+function gameParams(userId, g) {
+  return [userId, g.name, g.type ?? 'Board', g.complexity ?? 'Medium',
+    g.minPlayers ?? 1, g.maxPlayers ?? 1, g.playTime ?? 60,
+    g.age ?? 0, g.setupTime ?? 10, g.rating ?? null,
+    g.played ?? false, g.cooperative ?? false, g.thumbnail ?? null,
+    g.bggId ?? null, g.source ?? 'manual',
+    g.spotifyEmbedUrl ?? null, g.spotifyPlaylistName ?? null];
+}
+
+router.get("/api/games", async (req, res) => {
+  if (!pool) return res.json([]);
+  try {
+    const { rows } = await pool.query(
+      "SELECT * FROM games WHERE user_id = $1 ORDER BY name",
+      [req.user.id]
+    );
+    res.json(rows.map(normalizeGame));
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+router.post("/api/games/sync", async (req, res) => {
+  if (!pool) return res.status(503).json({ error: "Database not available" });
+  try {
+    const arr = req.body;
+    if (!Array.isArray(arr)) return res.status(400).json({ error: "Expected array" });
+    await pool.query("DELETE FROM games WHERE user_id = $1", [req.user.id]);
+    const result = [];
+    for (const g of arr) {
+      const { rows } = await pool.query(
+        `INSERT INTO games ${GAME_INSERT_COLS} VALUES ${GAME_INSERT_VALS} RETURNING *`,
+        gameParams(req.user.id, g)
+      );
+      result.push(rows[0]);
+    }
+    res.json(result.map(normalizeGame));
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+router.post("/api/games", async (req, res) => {
+  if (!pool) return res.status(503).json({ error: "Database not available" });
+  try {
+    const { rows } = await pool.query(
+      `INSERT INTO games ${GAME_INSERT_COLS} VALUES ${GAME_INSERT_VALS} RETURNING *`,
+      gameParams(req.user.id, req.body)
+    );
+    res.status(201).json(normalizeGame(rows[0]));
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+router.put("/api/games/:id", async (req, res) => {
+  if (!pool) return res.status(503).json({ error: "Database not available" });
+  try {
+    const fieldMap = {
+      name: 'name', type: 'type', complexity: 'complexity',
+      minPlayers: 'min_players', maxPlayers: 'max_players', playTime: 'play_time',
+      age: 'age', setupTime: 'setup_time', rating: 'rating', played: 'played',
+      cooperative: 'cooperative', thumbnail: 'thumbnail', bggId: 'bgg_id',
+      source: 'source', spotifyEmbedUrl: 'spotify_embed_url',
+      spotifyPlaylistName: 'spotify_playlist_name',
+    };
+    const sets = [];
+    const vals = [req.params.id, req.user.id];
+    let i = 3;
+    for (const [jsKey, col] of Object.entries(fieldMap)) {
+      if (jsKey in req.body) { sets.push(`${col} = $${i++}`); vals.push(req.body[jsKey]); }
+    }
+    if (!sets.length) return res.status(400).json({ error: "No fields to update" });
+    const { rows } = await pool.query(
+      `UPDATE games SET ${sets.join(', ')} WHERE id = $1 AND user_id = $2 RETURNING *`,
+      vals
+    );
+    if (!rows.length) return res.status(404).json({ error: "Not found" });
+    res.json(normalizeGame(rows[0]));
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+router.delete("/api/games/:id", async (req, res) => {
+  if (!pool) return res.status(503).json({ error: "Database not available" });
+  try {
+    await pool.query("DELETE FROM games WHERE id = $1 AND user_id = $2",
+      [req.params.id, req.user.id]);
+    res.json({});
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: err.message });
+  }
+});
+
 // ── Spotify ────────────────────────────────────────────────────────────────
 let spotifyToken = null;
 let spotifyTokenExpiry = 0;

--- a/tests/app.spec.js
+++ b/tests/app.spec.js
@@ -19,11 +19,20 @@ const MOCK_PLAYLISTS = {
   ],
 };
 
+// Default game library used by the /api/games mock in beforeEach.
+// Includes Low-complexity games (for filter tests) and Wingspan Asia (for 'wing' search test).
+const DEFAULT_TEST_GAMES = [
+  { id: 1, name: 'Wingspan Asia', type: 'Board', complexity: 'Medium', minPlayers: 1, maxPlayers: 2, playTime: 70, age: 14, setupTime: 10, rating: null, played: false, cooperative: false, thumbnail: null, bggId: 366161, source: 'bgg', spotifyEmbedUrl: null, spotifyPlaylistName: null },
+  { id: 2, name: 'Azul', type: 'Board', complexity: 'Medium', minPlayers: 2, maxPlayers: 4, playTime: 45, age: 8, setupTime: 5, rating: null, played: true, cooperative: false, thumbnail: null, bggId: 230802, source: 'bgg', spotifyEmbedUrl: null, spotifyPlaylistName: null },
+  { id: 3, name: 'Catan', type: 'Board', complexity: 'Medium', minPlayers: 3, maxPlayers: 6, playTime: 90, age: 10, setupTime: 10, rating: null, played: true, cooperative: false, thumbnail: null, bggId: 13, source: 'bgg', spotifyEmbedUrl: null, spotifyPlaylistName: null },
+  { id: 4, name: 'Codenames', type: 'Party', complexity: 'Low', minPlayers: 2, maxPlayers: 8, playTime: 15, age: 14, setupTime: 2, rating: null, played: true, cooperative: false, thumbnail: null, bggId: 178900, source: 'bgg', spotifyEmbedUrl: null, spotifyPlaylistName: null },
+  { id: 5, name: 'Fluxx', type: 'Card', complexity: 'Low', minPlayers: 2, maxPlayers: 6, playTime: 30, age: 8, setupTime: 1, rating: null, played: true, cooperative: false, thumbnail: null, bggId: 258, source: 'bgg', spotifyEmbedUrl: null, spotifyPlaylistName: null },
+];
+
 // Each test gets a fresh localStorage so state doesn't bleed between runs.
-// waitForLoadState('networkidle') ensures games.json fetch completes first.
-// /api/players is mocked so tests never hit the real database. The mock is
-// stateful within each test -- state resets between tests because mockPlayers
-// is declared in the beforeEach closure.
+// /api/players and /api/games are mocked so tests never hit the real database.
+// Both mocks are stateful within each test -- state resets between tests because
+// the mock arrays are declared in the beforeEach closure.
 test.beforeEach(async ({ page }) => {
   let mockPlayers = [];
   let nextId = 1;
@@ -50,6 +59,39 @@ test.beforeEach(async ({ page }) => {
       const id = parseInt(idSegment);
       mockPlayers = mockPlayers.filter(p => p.id !== id);
       await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({}) });
+    }
+  });
+
+  let mockGames = DEFAULT_TEST_GAMES.map(g => ({ ...g }));
+  let nextGameId = DEFAULT_TEST_GAMES.length + 1;
+
+  await page.route(url => url.href.includes('/api/games'), async (route) => {
+    const method = route.request().method();
+    const url = route.request().url();
+    const idSegment = url.match(/\/api\/games\/(\d+)/)?.[1];
+    const isSync = url.includes('/api/games/sync');
+
+    if (method === 'GET') {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(mockGames) });
+    } else if (method === 'POST' && isSync) {
+      const arr = route.request().postDataJSON();
+      mockGames = arr.map(g => ({ ...g, id: g.id ?? nextGameId++ }));
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(mockGames) });
+    } else if (method === 'POST') {
+      const body = route.request().postDataJSON();
+      const game = { ...body, id: nextGameId++ };
+      mockGames.push(game);
+      return route.fulfill({ status: 201, contentType: 'application/json', body: JSON.stringify(game) });
+    } else if (method === 'PUT' && idSegment) {
+      const id = parseInt(idSegment);
+      const body = route.request().postDataJSON();
+      const idx = mockGames.findIndex(g => g.id === id);
+      if (idx !== -1) mockGames[idx] = { ...mockGames[idx], ...body };
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(mockGames[idx] ?? {}) });
+    } else if (method === 'DELETE' && idSegment) {
+      const id = parseInt(idSegment);
+      mockGames = mockGames.filter(g => g.id !== id);
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({}) });
     }
   });
 
@@ -162,7 +204,7 @@ test('toggling a player on roll call updates the player count filter', async ({ 
 });
 
 // ── Find Games / Filters ───────────────────────────────────────────────────
-test('Find Games shows results from games.json', async ({ page }) => {
+test('Find Games shows results from library', async ({ page }) => {
   const main = new MainPage(page);
   await main.findGames();
   await main.expectResults();
@@ -226,16 +268,15 @@ test('quick search filters visible games', async ({ page }) => {
 
 // ── BGG badge on game cards ────────────────────────────────────────────────
 test('expanded game card shows BGG badge linking to boardgamegeek.com for a BGG game', async ({ page }) => {
-  const main = new MainPage(page);
+  const main    = new MainPage(page);
+  const library = new LibraryModal(page);
 
-  await page.evaluate(() => {
-    localStorage.setItem('sz-games', JSON.stringify([
-      { name: 'Ticket to Ride', minPlayers: 2, maxPlayers: 5, playTime: 60,
-        complexity: 'Low', type: 'Board', age: 8, setupTime: 10, rating: 4,
-        played: false, cooperative: false, thumbnail: null, bggId: 9209, source: 'bgg' },
-    ]));
-  });
-  await page.reload();
+  await library.seedGames([
+    { id: 101, name: 'Ticket to Ride', minPlayers: 2, maxPlayers: 5, playTime: 60,
+      complexity: 'Low', type: 'Board', age: 8, setupTime: 10, rating: 4,
+      played: false, cooperative: false, thumbnail: null, bggId: 9209, source: 'bgg',
+      spotifyEmbedUrl: null, spotifyPlaylistName: null },
+  ]);
 
   await main.findGames();
   await main.expandGameCard(0);
@@ -247,16 +288,15 @@ test('expanded game card shows BGG badge linking to boardgamegeek.com for a BGG 
 });
 
 test('expanded game card shows BGG badge linking to Google search for a manual game', async ({ page }) => {
-  const main = new MainPage(page);
+  const main    = new MainPage(page);
+  const library = new LibraryModal(page);
 
-  await page.evaluate(() => {
-    localStorage.setItem('sz-games', JSON.stringify([
-      { name: 'My Homebrew Game', minPlayers: 2, maxPlayers: 4, playTime: 30,
-        complexity: 'Low', type: 'Card', age: 0, setupTime: 5, rating: null,
-        played: false, cooperative: false, thumbnail: null, bggId: null, source: 'manual' },
-    ]));
-  });
-  await page.reload();
+  await library.seedGames([
+    { id: 102, name: 'My Homebrew Game', minPlayers: 2, maxPlayers: 4, playTime: 30,
+      complexity: 'Low', type: 'Card', age: 0, setupTime: 5, rating: null,
+      played: false, cooperative: false, thumbnail: null, bggId: null, source: 'manual',
+      spotifyEmbedUrl: null, spotifyPlaylistName: null },
+  ]);
 
   await main.findGames();
   await main.expandGameCard(0);
@@ -398,14 +438,12 @@ test('BGG sync preserves manually added games not in BGG response', async ({ pag
   const settings = new SettingsModal(page);
   const library  = new LibraryModal(page);
 
-  await page.evaluate(() => {
-    localStorage.setItem('sz-games', JSON.stringify([
-      { name: 'My Homebrew Game', minPlayers: 2, maxPlayers: 4, playTime: 30,
-        complexity: 'Low', type: 'Card', age: 0, setupTime: 5, rating: null,
-        played: false, cooperative: false, thumbnail: null, bggId: null, source: 'manual' },
-    ]));
-  });
-  await page.reload();
+  await library.seedGames([
+    { id: 201, name: 'My Homebrew Game', minPlayers: 2, maxPlayers: 4, playTime: 30,
+      complexity: 'Low', type: 'Card', age: 0, setupTime: 5, rating: null,
+      played: false, cooperative: false, thumbnail: null, bggId: null, source: 'manual',
+      spotifyEmbedUrl: null, spotifyPlaylistName: null },
+  ]);
 
   await settings.mockAndSync(route =>
     route.fulfill({ contentType: 'application/json', body: JSON.stringify({ games: [], count: 0 }) })
@@ -421,14 +459,12 @@ test('BGG sync updates fields on an existing BGG game matched by bggId', async (
   const settings = new SettingsModal(page);
   const library  = new LibraryModal(page);
 
-  await page.evaluate(() => {
-    localStorage.setItem('sz-games', JSON.stringify([
-      { name: 'Old Name', minPlayers: 2, maxPlayers: 4, playTime: 60,
-        complexity: 'Medium', type: 'Board', age: 0, setupTime: 10, rating: 3,
-        played: true, cooperative: false, thumbnail: null, bggId: 12345, source: 'bgg' },
-    ]));
-  });
-  await page.reload();
+  await library.seedGames([
+    { id: 202, name: 'Old Name', minPlayers: 2, maxPlayers: 4, playTime: 60,
+      complexity: 'Medium', type: 'Board', age: 0, setupTime: 10, rating: 3,
+      played: true, cooperative: false, thumbnail: null, bggId: 12345, source: 'bgg',
+      spotifyEmbedUrl: null, spotifyPlaylistName: null },
+  ]);
 
   await settings.mockAndSync(route =>
     route.fulfill({
@@ -453,11 +489,7 @@ test('BGG sync adds new games from BGG not yet in the local library', async ({ p
   const settings = new SettingsModal(page);
   const library  = new LibraryModal(page);
 
-  // Start with an empty library (clear any games.json defaults)
-  await page.evaluate(() => {
-    localStorage.setItem('sz-games', JSON.stringify([]));
-  });
-  await page.reload();
+  await library.seedGames([]);
 
   await settings.mockAndSync(route =>
     route.fulfill({
@@ -480,15 +512,14 @@ test('BGG sync adds new games from BGG not yet in the local library', async ({ p
 test('BGG sync backfills bggId on a name-matched manual game so badge links to BGG', async ({ page }) => {
   const settings = new SettingsModal(page);
   const main     = new MainPage(page);
+  const library  = new LibraryModal(page);
 
-  await page.evaluate(() => {
-    localStorage.setItem('sz-games', JSON.stringify([
-      { name: 'Ticket to Ride', minPlayers: 2, maxPlayers: 5, playTime: 60,
-        complexity: 'Low', type: 'Board', age: 8, setupTime: 10, rating: 4,
-        played: false, cooperative: false, thumbnail: null, bggId: null, source: 'manual' },
-    ]));
-  });
-  await page.reload();
+  await library.seedGames([
+    { id: 204, name: 'Ticket to Ride', minPlayers: 2, maxPlayers: 5, playTime: 60,
+      complexity: 'Low', type: 'Board', age: 8, setupTime: 10, rating: 4,
+      played: false, cooperative: false, thumbnail: null, bggId: null, source: 'manual',
+      spotifyEmbedUrl: null, spotifyPlaylistName: null },
+  ]);
 
   await settings.mockAndSync(route =>
     route.fulfill({
@@ -526,14 +557,12 @@ test('BGG sync preserves existing games when BGG returns empty collection', asyn
   const settings = new SettingsModal(page);
   const library  = new LibraryModal(page);
 
-  await page.evaluate(() => {
-    localStorage.setItem('sz-games', JSON.stringify([
-      { name: 'Keeper Game', minPlayers: 2, maxPlayers: 4, playTime: 60,
-        complexity: 'Medium', type: 'Board', age: 0, setupTime: 10, rating: null,
-        played: false, cooperative: false, thumbnail: null, bggId: 77777, source: 'bgg' },
-    ]));
-  });
-  await page.reload();
+  await library.seedGames([
+    { id: 205, name: 'Keeper Game', minPlayers: 2, maxPlayers: 4, playTime: 60,
+      complexity: 'Medium', type: 'Board', age: 0, setupTime: 10, rating: null,
+      played: false, cooperative: false, thumbnail: null, bggId: 77777, source: 'bgg',
+      spotifyEmbedUrl: null, spotifyPlaylistName: null },
+  ]);
 
   await settings.mockAndSync(route =>
     route.fulfill({ contentType: 'application/json',
@@ -544,6 +573,95 @@ test('BGG sync preserves existing games when BGG returns empty collection', asyn
   await settings.close();
   await library.open();
   await library.expectGame('Keeper Game');
+});
+
+// ── Games import prompt ────────────────────────────────────────────────────
+test('import prompt appears when localStorage has games and API returns empty library', async ({ page }) => {
+  await page.route(url => url.href.includes('/api/games'), async route => {
+    if (route.request().method() === 'GET' && !route.request().url().includes('/sync')) {
+      return route.fulfill({ contentType: 'application/json', body: JSON.stringify([]) });
+    }
+    return route.fallback();
+  });
+  await page.evaluate(() => {
+    localStorage.setItem('sz-games', JSON.stringify([
+      { name: 'Old Game', minPlayers: 2, maxPlayers: 4, playTime: 30,
+        complexity: 'Low', type: 'Card', age: 0, setupTime: 5,
+        rating: null, played: false, cooperative: false, thumbnail: null,
+        bggId: null, source: 'manual' },
+    ]));
+  });
+  await page.reload();
+  await page.waitForLoadState('networkidle');
+
+  const main = new MainPage(page);
+  await expect(main.gamesImportPrompt).toBeVisible();
+});
+
+test('importing local games calls sync endpoint and dismisses prompt', async ({ page }) => {
+  let syncCalled = false;
+
+  await page.route(url => url.href.includes('/api/games'), async route => {
+    const method = route.request().method();
+    const url = route.request().url();
+    if (method === 'GET' && !url.includes('/sync')) {
+      return route.fulfill({ contentType: 'application/json', body: JSON.stringify([]) });
+    }
+    if (method === 'POST' && url.includes('/sync')) {
+      syncCalled = true;
+      return route.fulfill({ contentType: 'application/json', body: JSON.stringify([
+        { id: 1, name: 'Old Game', type: 'Card', complexity: 'Low', minPlayers: 2, maxPlayers: 4,
+          playTime: 30, age: 0, setupTime: 5, rating: null, played: false, cooperative: false,
+          thumbnail: null, bggId: null, source: 'manual', spotifyEmbedUrl: null, spotifyPlaylistName: null },
+      ]) });
+    }
+    return route.fallback();
+  });
+  await page.evaluate(() => {
+    localStorage.setItem('sz-games', JSON.stringify([
+      { name: 'Old Game', minPlayers: 2, maxPlayers: 4, playTime: 30,
+        complexity: 'Low', type: 'Card', age: 0, setupTime: 5,
+        rating: null, played: false, cooperative: false, thumbnail: null,
+        bggId: null, source: 'manual' },
+    ]));
+  });
+  await page.reload();
+  await page.waitForLoadState('networkidle');
+
+  const main = new MainPage(page);
+  await main.gamesImportYes.click();
+  await page.waitForLoadState('networkidle');
+
+  expect(syncCalled).toBe(true);
+  await expect(main.gamesImportPrompt).not.toBeVisible();
+  const stored = await page.evaluate(() => localStorage.getItem('sz-games'));
+  expect(stored).toBeNull();
+});
+
+test('dismissing import prompt removes localStorage entry', async ({ page }) => {
+  await page.route(url => url.href.includes('/api/games'), async route => {
+    if (route.request().method() === 'GET' && !route.request().url().includes('/sync')) {
+      return route.fulfill({ contentType: 'application/json', body: JSON.stringify([]) });
+    }
+    return route.fallback();
+  });
+  await page.evaluate(() => {
+    localStorage.setItem('sz-games', JSON.stringify([
+      { name: 'Old Game', minPlayers: 2, maxPlayers: 4, playTime: 30,
+        complexity: 'Low', type: 'Card', age: 0, setupTime: 5,
+        rating: null, played: false, cooperative: false, thumbnail: null,
+        bggId: null, source: 'manual' },
+    ]));
+  });
+  await page.reload();
+  await page.waitForLoadState('networkidle');
+
+  const main = new MainPage(page);
+  await main.gamesImportNo.click();
+
+  await expect(main.gamesImportPrompt).not.toBeVisible();
+  const stored = await page.evaluate(() => localStorage.getItem('sz-games'));
+  expect(stored).toBeNull();
 });
 
 // ── History ────────────────────────────────────────────────────────────────

--- a/tests/pages/LibraryModal.js
+++ b/tests/pages/LibraryModal.js
@@ -70,6 +70,17 @@ class LibraryModal {
   async expectNoGame(gameName) {
     await expect(this.row(gameName)).toHaveCount(0);
   }
+
+  async seedGames(games) {
+    await this.page.route(url => url.href.includes('/api/games'), async route => {
+      if (route.request().method() === 'GET' && !route.request().url().includes('/sync')) {
+        return route.fulfill({ contentType: 'application/json', body: JSON.stringify(games) });
+      }
+      return route.fallback();
+    });
+    await this.page.reload();
+    await this.page.waitForLoadState('networkidle');
+  }
 }
 
 module.exports = { LibraryModal };

--- a/tests/pages/MainPage.js
+++ b/tests/pages/MainPage.js
@@ -28,6 +28,11 @@ class MainPage {
     this.newOnlyBtn      = page.getByTestId('new-only-btn');
     this.coopBtn         = page.getByTestId('coop-btn');
 
+    // Games import prompt
+    this.gamesImportPrompt = page.getByTestId('games-import-prompt');
+    this.gamesImportYes    = page.getByTestId('games-import-yes');
+    this.gamesImportNo     = page.getByTestId('games-import-no');
+
     // Action buttons
     this.findGamesBtn = page.getByTestId('btn-find-games');
     this.surpriseBtn  = page.getByTestId('btn-surprise');


### PR DESCRIPTION
## Summary
- Adds `games` table to schema and full CRUD API (`GET`, `POST`, `PUT`, `DELETE`, `POST /sync`)
- Replaces all localStorage reads/writes in `app.js` with API calls using write-through caching
- Shows an import prompt when a user has games in localStorage but an empty database library
- Mocks `/api/games` in test `beforeEach` with a stateful handler; all BGG sync and badge tests updated to use `library.seedGames()` instead of localStorage seeding
- Adds 3 new tests for the import prompt (appears, import, dismiss)

## Test plan
- [ ] All 51 existing tests pass
- [ ] 3 new import prompt tests pass
- [ ] BGG sync tests use `library.seedGames()` instead of `localStorage.setItem`
- [ ] BGG badge tests use `library.seedGames()` instead of `localStorage.setItem`

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)