### PR TITLE
Migrate play history and active sessions to Postgres

### DIFF
--- a/app.js
+++ b/app.js
@@ -49,6 +49,10 @@ let currentSpotifyOptions = [];   // full list returned by last fetch
 const SETTINGS_DEFAULTS = { showWhyBtn: true };
 let settings = { ...SETTINGS_DEFAULTS };
 
+// Play History and Active Sessions
+let history = [];
+let activeSessions = [];
+
 // ── Init ───────────────────────────────────────────────────────────────────
 if (isDemoMode()) {
   fetch("demo-games.json")
@@ -80,6 +84,8 @@ if (!isDemoMode()) {
   initVault();
   initSettings();
   initGames();
+  initHistory();
+  initActiveSessions();
 }
 
 // ── Navigation ─────────────────────────────────────────────────────────────
@@ -193,6 +199,86 @@ async function importLocalGames() {
 function dismissGamesImportPrompt() {
   localStorage.removeItem('sz-games');
   document.getElementById('games-import-prompt')?.classList.add('hidden');
+}
+
+async function initHistory() {
+  try {
+    const res = await fetch('/api/history');
+    if (!res.ok) return;
+    history = await res.json();
+  } catch {
+    // Network error - history stays empty
+  }
+  checkHistoryLocalStorageImport();
+}
+
+function checkHistoryLocalStorageImport() {
+  if (history.length > 0) return;
+  const legacy = localStorage.getItem('sz-history');
+  if (!legacy) return;
+  document.getElementById('history-import-prompt')?.classList.remove('hidden');
+}
+
+async function importLocalHistory() {
+  const legacy = JSON.parse(localStorage.getItem('sz-history') || '[]');
+  if (legacy.length === 0) { dismissHistoryImportPrompt(); return; }
+  try {
+    const res = await fetch('/api/history/sync', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(legacy),
+    });
+    if (res.ok) history = legacy;
+  } catch {}
+  localStorage.removeItem('sz-history');
+  document.getElementById('history-import-prompt')?.classList.add('hidden');
+}
+
+function dismissHistoryImportPrompt() {
+  localStorage.removeItem('sz-history');
+  document.getElementById('history-import-prompt')?.classList.add('hidden');
+}
+
+async function initActiveSessions() {
+  try {
+    const res = await fetch('/api/sessions/active');
+    if (!res.ok) return;
+    activeSessions = await res.json();
+  } catch {
+    // Network error - activeSessions stays empty
+  }
+  checkActiveSessionsImport();
+  renderGamesInProgress();
+}
+
+function checkActiveSessionsImport() {
+  if (activeSessions.length > 0) return;
+  const legacy = localStorage.getItem('sz-active-sessions');
+  if (!legacy) return;
+  document.getElementById('active-sessions-import-prompt')?.classList.remove('hidden');
+}
+
+async function importLocalActiveSessions() {
+  const legacy = JSON.parse(localStorage.getItem('sz-active-sessions') || '[]');
+  if (legacy.length === 0) { dismissActiveSessionsImportPrompt(); return; }
+  try {
+    await Promise.all(legacy.map(state =>
+      fetch('/api/sessions/active', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(state),
+      })
+    ));
+    activeSessions = legacy;
+  } catch {}
+  localStorage.removeItem('sz-active-sessions');
+  document.getElementById('active-sessions-import-prompt')?.classList.add('hidden');
+  renderGamesInProgress();
+}
+
+function dismissActiveSessionsImportPrompt() {
+  localStorage.removeItem('sz-active-sessions');
+  document.getElementById('active-sessions-import-prompt')?.classList.add('hidden');
 }
 
 function checkLocalStorageImport() {
@@ -1258,9 +1344,12 @@ function backToSession() {
 
 function saveResult(result) {
   if (isDemoMode()) return;
-  const history = JSON.parse(localStorage.getItem('sz-history') || '[]');
   history.unshift(result);
-  localStorage.setItem('sz-history', JSON.stringify(history));
+  fetch('/api/history', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(result),
+  }).catch(() => {});
 
   // Stamp lastPlayed on each participating vault player
   result.players.forEach(rp => {
@@ -1307,19 +1396,21 @@ function pauseSession() {
     pausedAt: new Date().toISOString(),
   };
   if (!isDemoMode()) {
-    const sessions = JSON.parse(localStorage.getItem('sz-active-sessions') || '[]');
-    const idx = sessions.findIndex(s => s.id === state.id);
-    if (idx >= 0) sessions[idx] = state;
-    else sessions.push(state);
-    localStorage.setItem('sz-active-sessions', JSON.stringify(sessions));
+    const idx = activeSessions.findIndex(s => s.id === state.id);
+    if (idx >= 0) activeSessions[idx] = state;
+    else activeSessions.push(state);
+    fetch('/api/sessions/active', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(state),
+    }).catch(() => {});
   }
   document.getElementById('session-modal').classList.remove('active');
   renderGamesInProgress();
 }
 
 function resumeSession(sessionId) {
-  const sessions = JSON.parse(localStorage.getItem('sz-active-sessions') || '[]');
-  const state = sessions.find(s => s.id === sessionId);
+  const state = activeSessions.find(s => s.id === sessionId);
   if (!state) return;
 
   currentSessionId   = state.id;
@@ -1342,7 +1433,7 @@ function resumeSession(sessionId) {
 }
 
 function renderGamesInProgress() {
-  const sessions = JSON.parse(localStorage.getItem('sz-active-sessions') || '[]');
+  const sessions = activeSessions;
   const section = document.getElementById('games-in-progress');
   const list = document.getElementById('gip-list');
   if (!section || !list) return;
@@ -1383,7 +1474,6 @@ function closeHistory() {
 }
 
 function renderHistory() {
-  const history = JSON.parse(localStorage.getItem('sz-history') || '[]');
   const container = document.getElementById('history-list');
   if (!container) return;
 
@@ -1475,7 +1565,6 @@ function switchStatsTab(tab) {
 }
 
 function computePlayerStats(playerId) {
-  const history = JSON.parse(localStorage.getItem('sz-history') || '[]');
   const sessions = history.filter(e => e.players.some(p => p.id === playerId));
   const gamesPlayed = sessions.length;
 
@@ -1590,7 +1679,6 @@ function selectH2HPlayer(side, id) {
 }
 
 function computeHeadToHead(idA, idB) {
-  const history = JSON.parse(localStorage.getItem('sz-history') || '[]');
   const shared = history.filter(e =>
     e.players.some(p => p.id === idA) && e.players.some(p => p.id === idB)
   );
@@ -1691,6 +1779,7 @@ function finalizeSession() {
     id: currentSessionId,
     date: new Date().toISOString().split('T')[0],
     game: sessionGame.name,
+    gameId: sessionGame?.id ?? null,
     mode: scoreMode,
     ...(scoreMode === 'winlose' ? { outcome: sessionOutcome } : { lowScoreWins: lowWins }),
     players,
@@ -1707,10 +1796,9 @@ function finalizeSession() {
   saveResult(result);
 
   if (!isDemoMode()) {
-    const sessions = JSON.parse(localStorage.getItem('sz-active-sessions') || '[]');
-    localStorage.setItem('sz-active-sessions',
-      JSON.stringify(sessions.filter(s => s.id !== currentSessionId))
-    );
+    const removedId = currentSessionId;
+    activeSessions = activeSessions.filter(s => s.id !== removedId);
+    fetch(`/api/sessions/active/${removedId}`, { method: 'DELETE' }).catch(() => {});
   }
 
   currentSessionId = null;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -54,3 +54,35 @@ CREATE TABLE IF NOT EXISTS settings (
   bgg_last_sync       TEXT,
   bgg_last_sync_count INTEGER
 );
+
+CREATE TABLE IF NOT EXISTS sessions (
+  id               TEXT PRIMARY KEY,
+  user_id          INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  game_name        TEXT NOT NULL,
+  game_id          INTEGER REFERENCES games(id) ON DELETE SET NULL,
+  played_at        DATE NOT NULL,
+  duration_seconds INTEGER NOT NULL DEFAULT 0,
+  mode             TEXT NOT NULL DEFAULT 'scores',
+  outcome          TEXT,
+  low_score_wins   BOOLEAN DEFAULT FALSE,
+  created_at       TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS session_players (
+  id                   SERIAL PRIMARY KEY,
+  session_id           TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+  player_id            TEXT NOT NULL,
+  player_name          TEXT NOT NULL,
+  score                INTEGER,
+  winner               BOOLEAN DEFAULT FALSE,
+  feedback_rating      INTEGER,
+  feedback_play_again  TEXT,
+  feedback_notes       TEXT
+);
+
+CREATE TABLE IF NOT EXISTS active_sessions (
+  id        TEXT PRIMARY KEY,
+  user_id   INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  data      JSONB NOT NULL,
+  paused_at TIMESTAMPTZ
+);

--- a/index.html
+++ b/index.html
@@ -45,6 +45,18 @@
       <button onclick="dismissGamesImportPrompt()" data-testid="games-import-no">No thanks</button>
     </div>
 
+    <div id="history-import-prompt" data-testid="history-import-prompt" class="vault-import-prompt hidden">
+      <span>We found play history on this device. Import it to your account?</span>
+      <button onclick="importLocalHistory()" data-testid="history-import-yes">Import</button>
+      <button onclick="dismissHistoryImportPrompt()" data-testid="history-import-no">No thanks</button>
+    </div>
+
+    <div id="active-sessions-import-prompt" data-testid="active-sessions-import-prompt" class="vault-import-prompt hidden">
+      <span>We found paused sessions on this device. Import them to your account?</span>
+      <button onclick="importLocalActiveSessions()" data-testid="active-sessions-import-yes">Import</button>
+      <button onclick="dismissActiveSessionsImportPrompt()" data-testid="active-sessions-import-no">No thanks</button>
+    </div>
+
     <section class="games-in-progress hidden" id="games-in-progress">
       <h2 class="section-label">Games in Progress</h2>
       <div id="gip-list" class="gip-list"></div>

--- a/routes/api.js
+++ b/routes/api.js
@@ -255,6 +255,167 @@ router.delete("/api/games/:id", async (req, res) => {
   }
 });
 
+// ── History ────────────────────────────────────────────────────────────────
+function normalizeHistoryEntry(row) {
+  const players = (row.players_data || []).filter(Boolean);
+  return {
+    id: row.id,
+    date: String(row.played_at).split('T')[0],
+    game: row.game_name,
+    mode: row.mode,
+    ...(row.mode === 'winlose' ? { outcome: row.outcome } : { lowScoreWins: row.low_score_wins }),
+    timerSeconds: row.duration_seconds,
+    players: players.map(sp => {
+      const p = { id: sp.player_id, name: sp.player_name };
+      if (row.mode !== 'winlose') { p.score = sp.score; p.winner = sp.winner; }
+      return p;
+    }),
+    feedback: Object.fromEntries(
+      players
+        .filter(sp => sp.feedback_rating || sp.feedback_play_again || sp.feedback_notes)
+        .map(sp => [sp.player_id, {
+          rating: sp.feedback_rating,
+          playAgain: sp.feedback_play_again,
+          notes: sp.feedback_notes,
+        }])
+    ),
+  };
+}
+
+async function insertHistoryEntry(client, userId, entry) {
+  await client.query(
+    `INSERT INTO sessions (id, user_id, game_name, game_id, played_at, duration_seconds, mode, outcome, low_score_wins)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+     ON CONFLICT (id) DO NOTHING`,
+    [entry.id, userId, entry.game, entry.gameId ?? null, entry.date,
+     entry.timerSeconds ?? 0, entry.mode ?? 'scores',
+     entry.outcome ?? null, entry.lowScoreWins ?? false]
+  );
+  for (const p of (entry.players || [])) {
+    const fb = entry.feedback?.[p.id] ?? {};
+    await client.query(
+      `INSERT INTO session_players (session_id, player_id, player_name, score, winner, feedback_rating, feedback_play_again, feedback_notes)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+      [entry.id, String(p.id), p.name, p.score ?? null, p.winner ?? false,
+       fb.rating ?? null, fb.playAgain ?? null, fb.notes ?? null]
+    );
+  }
+}
+
+router.get("/api/history", async (req, res) => {
+  if (!pool) return res.json([]);
+  try {
+    const { rows } = await pool.query(
+      `SELECT s.id, s.game_name, s.game_id, s.played_at, s.duration_seconds, s.mode, s.outcome, s.low_score_wins,
+              json_agg(json_build_object(
+                'player_id', sp.player_id, 'player_name', sp.player_name,
+                'score', sp.score, 'winner', sp.winner,
+                'feedback_rating', sp.feedback_rating, 'feedback_play_again', sp.feedback_play_again,
+                'feedback_notes', sp.feedback_notes
+              ) ORDER BY sp.id) AS players_data
+       FROM sessions s
+       LEFT JOIN session_players sp ON sp.session_id = s.id
+       WHERE s.user_id = $1
+       GROUP BY s.id
+       ORDER BY s.played_at DESC, s.created_at DESC`,
+      [req.user.id]
+    );
+    res.json(rows.map(normalizeHistoryEntry));
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+router.post("/api/history/sync", async (req, res) => {
+  if (!pool) return res.status(503).json({ error: "Database not available" });
+  try {
+    const arr = req.body;
+    if (!Array.isArray(arr)) return res.status(400).json({ error: "Expected array" });
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+      for (const entry of arr) await insertHistoryEntry(client, req.user.id, entry);
+      await client.query('COMMIT');
+    } catch (err) {
+      await client.query('ROLLBACK');
+      throw err;
+    } finally {
+      client.release();
+    }
+    res.json({ count: arr.length });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+router.post("/api/history", async (req, res) => {
+  if (!pool) return res.status(503).json({ error: "Database not available" });
+  try {
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+      await insertHistoryEntry(client, req.user.id, req.body);
+      await client.query('COMMIT');
+    } catch (err) {
+      await client.query('ROLLBACK');
+      throw err;
+    } finally {
+      client.release();
+    }
+    res.status(201).json({});
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// ── Active Sessions ────────────────────────────────────────────────────────
+router.get("/api/sessions/active", async (req, res) => {
+  if (!pool) return res.json([]);
+  try {
+    const { rows } = await pool.query(
+      "SELECT data FROM active_sessions WHERE user_id = $1 ORDER BY paused_at DESC",
+      [req.user.id]
+    );
+    res.json(rows.map(r => r.data));
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+router.put("/api/sessions/active", async (req, res) => {
+  if (!pool) return res.status(503).json({ error: "Database not available" });
+  try {
+    const state = req.body;
+    await pool.query(
+      `INSERT INTO active_sessions (id, user_id, data, paused_at) VALUES ($1, $2, $3, $4)
+       ON CONFLICT (id) DO UPDATE SET data = EXCLUDED.data, paused_at = EXCLUDED.paused_at`,
+      [state.id, req.user.id, JSON.stringify(state), state.pausedAt ?? new Date().toISOString()]
+    );
+    res.json({});
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+router.delete("/api/sessions/active/:id", async (req, res) => {
+  if (!pool) return res.status(503).json({ error: "Database not available" });
+  try {
+    await pool.query(
+      "DELETE FROM active_sessions WHERE id = $1 AND user_id = $2",
+      [req.params.id, req.user.id]
+    );
+    res.json({});
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: err.message });
+  }
+});
+
 // ── Spotify ────────────────────────────────────────────────────────────────
 let spotifyToken = null;
 let spotifyTokenExpiry = 0;

--- a/tests/app.spec.js
+++ b/tests/app.spec.js
@@ -95,6 +95,47 @@ test.beforeEach(async ({ page }) => {
     }
   });
 
+  let mockHistory = [];
+
+  await page.route(url => url.href.includes('/api/history'), async (route) => {
+    const method = route.request().method();
+    const url = route.request().url();
+    const isSync = url.includes('/api/history/sync');
+
+    if (method === 'GET') {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(mockHistory) });
+    } else if (method === 'POST' && isSync) {
+      const arr = route.request().postDataJSON();
+      mockHistory = [...arr, ...mockHistory];
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ count: arr.length }) });
+    } else if (method === 'POST') {
+      const entry = route.request().postDataJSON();
+      mockHistory.unshift(entry);
+      return route.fulfill({ status: 201, contentType: 'application/json', body: JSON.stringify({}) });
+    }
+  });
+
+  let mockActiveSessions = [];
+
+  await page.route(url => url.href.includes('/api/sessions/active'), async (route) => {
+    const method = route.request().method();
+    const url = route.request().url();
+    const idSegment = url.match(/\/api\/sessions\/active\/([^/?]+)/)?.[1];
+
+    if (method === 'GET') {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(mockActiveSessions) });
+    } else if (method === 'PUT') {
+      const state = route.request().postDataJSON();
+      const idx = mockActiveSessions.findIndex(s => s.id === state.id);
+      if (idx >= 0) mockActiveSessions[idx] = state;
+      else mockActiveSessions.push(state);
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({}) });
+    } else if (method === 'DELETE' && idSegment) {
+      mockActiveSessions = mockActiveSessions.filter(s => s.id !== idSegment);
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({}) });
+    }
+  });
+
   await page.goto('/');
   await page.evaluate(() => localStorage.clear());
   await page.reload();
@@ -664,11 +705,224 @@ test('dismissing import prompt removes localStorage entry', async ({ page }) => 
   expect(stored).toBeNull();
 });
 
+// ── History import prompt ──────────────────────────────────────────────────
+test('history import prompt appears when localStorage has history and API returns empty', async ({ page }) => {
+  await page.route(url => url.href.includes('/api/history'), async route => {
+    if (route.request().method() === 'GET') {
+      return route.fulfill({ contentType: 'application/json', body: JSON.stringify([]) });
+    }
+    return route.fallback();
+  });
+  await page.evaluate(() => {
+    localStorage.setItem('sz-history', JSON.stringify([
+      { id: 'h1', date: '2025-01-01', game: 'Azul', mode: 'scores', lowScoreWins: false,
+        timerSeconds: 1800, players: [], feedback: {} },
+    ]));
+  });
+  await page.reload();
+  await page.waitForLoadState('networkidle');
+
+  const main = new MainPage(page);
+  await expect(main.historyImportPrompt).toBeVisible();
+});
+
+test('importing local history calls sync endpoint and dismisses prompt', async ({ page }) => {
+  let syncCalled = false;
+
+  await page.route(url => url.href.includes('/api/history'), async route => {
+    const method = route.request().method();
+    const url = route.request().url();
+    if (method === 'GET') {
+      return route.fulfill({ contentType: 'application/json', body: JSON.stringify([]) });
+    }
+    if (method === 'POST' && url.includes('/sync')) {
+      syncCalled = true;
+      return route.fulfill({ contentType: 'application/json', body: JSON.stringify({ count: 1 }) });
+    }
+    return route.fallback();
+  });
+  await page.evaluate(() => {
+    localStorage.setItem('sz-history', JSON.stringify([
+      { id: 'h1', date: '2025-01-01', game: 'Azul', mode: 'scores', lowScoreWins: false,
+        timerSeconds: 1800, players: [], feedback: {} },
+    ]));
+  });
+  await page.reload();
+  await page.waitForLoadState('networkidle');
+
+  const main = new MainPage(page);
+  await main.historyImportYes.click();
+  await page.waitForLoadState('networkidle');
+
+  expect(syncCalled).toBe(true);
+  await expect(main.historyImportPrompt).not.toBeVisible();
+  const stored = await page.evaluate(() => localStorage.getItem('sz-history'));
+  expect(stored).toBeNull();
+});
+
+test('dismissing history import prompt removes localStorage entry', async ({ page }) => {
+  await page.route(url => url.href.includes('/api/history'), async route => {
+    if (route.request().method() === 'GET') {
+      return route.fulfill({ contentType: 'application/json', body: JSON.stringify([]) });
+    }
+    return route.fallback();
+  });
+  await page.evaluate(() => {
+    localStorage.setItem('sz-history', JSON.stringify([
+      { id: 'h1', date: '2025-01-01', game: 'Azul', mode: 'scores', lowScoreWins: false,
+        timerSeconds: 1800, players: [], feedback: {} },
+    ]));
+  });
+  await page.reload();
+  await page.waitForLoadState('networkidle');
+
+  const main = new MainPage(page);
+  await main.historyImportNo.click();
+
+  await expect(main.historyImportPrompt).not.toBeVisible();
+  const stored = await page.evaluate(() => localStorage.getItem('sz-history'));
+  expect(stored).toBeNull();
+});
+
+// ── Active sessions import prompt ──────────────────────────────────────────
+test('active sessions import prompt appears when localStorage has paused session', async ({ page }) => {
+  await page.route(url => url.href.includes('/api/sessions/active'), async route => {
+    if (route.request().method() === 'GET') {
+      return route.fulfill({ contentType: 'application/json', body: JSON.stringify([]) });
+    }
+    return route.fallback();
+  });
+  await page.evaluate(() => {
+    localStorage.setItem('sz-active-sessions', JSON.stringify([
+      { id: 'sess-1', game: { id: 1, name: 'Azul' }, players: [], scores: {},
+        scoreMode: 'scores', lowScoreWins: false, outcome: null,
+        timerSeconds: 300, pausedAt: new Date().toISOString() },
+    ]));
+  });
+  await page.reload();
+  await page.waitForLoadState('networkidle');
+
+  const main = new MainPage(page);
+  await expect(main.activeSessionsImportPrompt).toBeVisible();
+});
+
+test('importing local active sessions calls PUT endpoint and dismisses prompt', async ({ page }) => {
+  let putCalled = false;
+
+  await page.route(url => url.href.includes('/api/sessions/active'), async route => {
+    const method = route.request().method();
+    if (method === 'GET') {
+      return route.fulfill({ contentType: 'application/json', body: JSON.stringify([]) });
+    }
+    if (method === 'PUT') {
+      putCalled = true;
+      return route.fulfill({ contentType: 'application/json', body: JSON.stringify({}) });
+    }
+    return route.fallback();
+  });
+  await page.evaluate(() => {
+    localStorage.setItem('sz-active-sessions', JSON.stringify([
+      { id: 'sess-1', game: { id: 1, name: 'Azul' }, players: [], scores: {},
+        scoreMode: 'scores', lowScoreWins: false, outcome: null,
+        timerSeconds: 300, pausedAt: new Date().toISOString() },
+    ]));
+  });
+  await page.reload();
+  await page.waitForLoadState('networkidle');
+
+  const main = new MainPage(page);
+  await main.activeSessionsImportYes.click();
+  await page.waitForLoadState('networkidle');
+
+  expect(putCalled).toBe(true);
+  await expect(main.activeSessionsImportPrompt).not.toBeVisible();
+  const stored = await page.evaluate(() => localStorage.getItem('sz-active-sessions'));
+  expect(stored).toBeNull();
+});
+
+test('dismissing active sessions import prompt removes localStorage entry', async ({ page }) => {
+  await page.route(url => url.href.includes('/api/sessions/active'), async route => {
+    if (route.request().method() === 'GET') {
+      return route.fulfill({ contentType: 'application/json', body: JSON.stringify([]) });
+    }
+    return route.fallback();
+  });
+  await page.evaluate(() => {
+    localStorage.setItem('sz-active-sessions', JSON.stringify([
+      { id: 'sess-1', game: { id: 1, name: 'Azul' }, players: [], scores: {},
+        scoreMode: 'scores', lowScoreWins: false, outcome: null,
+        timerSeconds: 300, pausedAt: new Date().toISOString() },
+    ]));
+  });
+  await page.reload();
+  await page.waitForLoadState('networkidle');
+
+  const main = new MainPage(page);
+  await main.activeSessionsImportNo.click();
+
+  await expect(main.activeSessionsImportPrompt).not.toBeVisible();
+  const stored = await page.evaluate(() => localStorage.getItem('sz-active-sessions'));
+  expect(stored).toBeNull();
+});
+
 // ── History ────────────────────────────────────────────────────────────────
 test('history modal opens and list renders', async ({ page }) => {
   const history = new HistoryModal(page);
   await history.open();
   await expect(history.list).toBeVisible();
+});
+
+test('history shows empty state when no sessions recorded', async ({ page }) => {
+  const history = new HistoryModal(page);
+  await history.open();
+  await expect(history.list).toContainText('No sessions recorded yet.');
+});
+
+test('finalized session appears in history list', async ({ page }) => {
+  const main    = new MainPage(page);
+  const session = new SessionModal(page);
+  const history = new HistoryModal(page);
+
+  await main.findGames();
+  const gameName = await main.gameCards().nth(0).getByTestId('game-name').textContent();
+  await main.letsPlay(0);
+  await session.finalize();
+
+  await history.open();
+  await expect(history.card(gameName)).toBeVisible();
+});
+
+test('paused session appears in Games in Progress', async ({ page }) => {
+  const main    = new MainPage(page);
+  const session = new SessionModal(page);
+
+  await main.findGames();
+  const gameName = await main.gameCards().nth(0).getByTestId('game-name').textContent();
+  await main.letsPlay(0);
+
+  await session.pauseBtn.click();
+  await expect(session.modal).not.toHaveClass(/active/);
+
+  const gip = page.locator('.gip-game');
+  await expect(gip).toBeVisible();
+  await expect(gip).toContainText(gameName);
+});
+
+test('resumed session restores game title', async ({ page }) => {
+  const main    = new MainPage(page);
+  const session = new SessionModal(page);
+
+  await main.findGames();
+  const gameName = await main.gameCards().nth(0).getByTestId('game-name').textContent();
+  await main.letsPlay(0);
+  await session.pauseBtn.click();
+
+  const resumeBtn = page.locator('.resume-btn').first();
+  await expect(resumeBtn).toBeVisible();
+  await resumeBtn.click();
+
+  await session.expectOpen();
+  await session.expectTitle(gameName);
 });
 
 // ── Stats ──────────────────────────────────────────────────────────────────

--- a/tests/pages/HistoryModal.js
+++ b/tests/pages/HistoryModal.js
@@ -16,6 +16,21 @@ class HistoryModal {
     await this.page.getByTestId('history-section-modal-close').click();
     await expect(this.modal).not.toHaveClass(/active/);
   }
+
+  async seedHistory(entries) {
+    await this.page.route(url => url.href.includes('/api/history'), async route => {
+      if (route.request().method() === 'GET') {
+        return route.fulfill({ contentType: 'application/json', body: JSON.stringify(entries) });
+      }
+      return route.fallback();
+    });
+    await this.page.reload();
+    await this.page.waitForLoadState('networkidle');
+  }
+
+  card(gameName) {
+    return this.list.locator('.history-card').filter({ hasText: gameName });
+  }
 }
 
 module.exports = { HistoryModal };

--- a/tests/pages/MainPage.js
+++ b/tests/pages/MainPage.js
@@ -33,6 +33,16 @@ class MainPage {
     this.gamesImportYes    = page.getByTestId('games-import-yes');
     this.gamesImportNo     = page.getByTestId('games-import-no');
 
+    // History import prompt
+    this.historyImportPrompt = page.getByTestId('history-import-prompt');
+    this.historyImportYes    = page.getByTestId('history-import-yes');
+    this.historyImportNo     = page.getByTestId('history-import-no');
+
+    // Active sessions import prompt
+    this.activeSessionsImportPrompt = page.getByTestId('active-sessions-import-prompt');
+    this.activeSessionsImportYes    = page.getByTestId('active-sessions-import-yes');
+    this.activeSessionsImportNo     = page.getByTestId('active-sessions-import-no');
+
     // Action buttons
     this.findGamesBtn = page.getByTestId('btn-find-games');
     this.surpriseBtn  = page.getByTestId('btn-surprise');

--- a/tests/pages/SessionModal.js
+++ b/tests/pages/SessionModal.js
@@ -45,6 +45,12 @@ class SessionModal {
   async expectTimerStopped() {
     await expect(this.timerBtn).toHaveText('Start');
   }
+
+  async finalize() {
+    await this.endGameBtn.click();
+    await expect(this.finalizeBtn).toBeVisible();
+    await this.finalizeBtn.click();
+  }
 }
 
 module.exports = { SessionModal };


### PR DESCRIPTION
## Summary
- Adds `sessions`, `session_players`, and `active_sessions` tables to schema
- Full history API: `GET /api/history`, `POST /api/history`, `POST /api/history/sync`
- Full active sessions API: `GET /api/sessions/active`, `PUT /api/sessions/active`, `DELETE /api/sessions/active/:id`
- All localStorage reads/writes replaced with in-memory arrays + fire-and-forget API calls
- Import prompts for both `sz-history` and `sz-active-sessions` localStorage keys (same pattern as vault and games)
- `game_name` denormalized alongside nullable `game_id` FK so history is stable if game is deleted
- Active sessions stored as JSONB blobs
- 10 new tests: 4 behavioral (empty state, finalize, pause, resume) + 6 import prompt tests

## Test plan
- [ ] All 61 tests pass (51 pre-existing + 10 new)
- [ ] `finalized session appears in history list` exercises the full end-game flow
- [ ] `paused session appears in Games in Progress` and `resumed session restores game title` cover the pause/resume cycle
- [ ] All 6 import prompt tests (history + active sessions) cover appears, import, and dismiss paths

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)