### PR TITLE
Add AI strategy document to docs

### DIFF
--- a/docs/ai-strategy.md
+++ b/docs/ai-strategy.md
@@ -1,0 +1,172 @@
+# AI Strategy for a QA Organization
+
+## Executive Summary
+
+Most QA teams sit at one of two extremes: either they have no AI presence and are falling behind, or they've adopted AI tools chaotically with no standardization and are seeing inconsistent results. Neither produces the quality improvements leadership expects.
+
+This document outlines a practical strategy for introducing AI into a QA organization in a way that improves quality, builds team confidence, and creates repeatable practices that scale -- without disrupting what already works.
+
+---
+
+## The Core Principle
+
+AI does not replace QA engineers. It removes the parts of QA work that are slow, repetitive, and error-prone -- freeing engineers to focus on the work that actually requires human judgment: exploratory testing, edge case analysis, release risk assessment, and quality advocacy.
+
+The failure mode is moving too fast. Companies that replace human QA with AI wholesale discover within months that AI-generated code creates new categories of bugs that AI-generated tests don't catch. The correct model is augmentation, not replacement.
+
+The opportunity cost of moving too slowly is equally real. Teams that wait for perfect information while competitors ship AI-assisted quality frameworks will find themselves outpaced. A certain amount of risk is inherent in changing the way you work. The goal is managing that risk deliberately, not eliminating it.
+
+---
+
+## Target Organization
+
+This strategy is written for a mid-size engineering organization (10-20 person QA team) that has:
+- Established manual testing practices
+- Some existing automation (Playwright, Cypress, or similar)
+- Leadership buy-in on AI adoption but uncertainty about implementation
+- A need for standardized, repeatable practices across the team
+
+The primary concern from leadership is quality. The question is not "should we use AI?" but "how do we use AI without letting quality slip?"
+
+The answer is governance.
+
+---
+
+## The 90-Day Plan
+
+### Days 1-30: Assess and Standardize
+
+The first month is not about building new things. It is about understanding what exists and establishing the foundation everything else will build on.
+
+**Week 1-2: Audit**
+- Map the current test suite: what is covered, what is not, what is flaky
+- Identify the highest-value manual testing workflows -- the ones that are slow, repetitive, and well-understood
+- Talk to every engineer on the team: what do they find tedious, what do they worry about, what would they automate if they could
+
+**Week 3-4: Foundation**
+- Establish a prompt library -- a version-controlled set of standardized prompts for common QA tasks (test case generation, failure analysis, release notes)
+- Define the team's AI governance rules: what AI can and cannot do, how outputs are reviewed, how prompts are maintained
+- Document everything in a CLAUDE.md-style context file so every engineer's AI assistant starts from the same shared understanding of the project
+
+**Success at day 30:** Every engineer on the team is using the same prompts, the same tools, and the same review process. No one is prompting differently.
+
+---
+
+### Days 31-60: Build the AI QA Layer
+
+With a foundation in place, the second month introduces the tools that directly improve quality metrics.
+
+**AI-assisted test generation**
+Use structured prompts to generate Playwright test cases from GitHub Issues and user stories. The output is reviewed by a human engineer before it enters the suite -- AI proposes, human approves. This accelerates test coverage without reducing quality bar.
+
+**AI failure analysis**
+When CI tests fail, pipe the output to an AI model for root cause analysis. The report surfaces probable cause, affected component, and suggested fix. Engineers still fix the bug -- but they start with better information and spend less time debugging.
+
+**AI release risk assessment**
+Before each release, generate a summary of what changed, what tests cover it, and what areas are at risk. This gives the release manager a structured artifact to review rather than a mental reconstruction of the sprint.
+
+**Success at day 60:** The team has measurably faster test authoring, faster failure diagnosis, and a structured release process. Quality metrics are trending up, not down.
+
+---
+
+### Days 61-90: Standardize and Scale
+
+The third month is about making the new practices permanent and expanding them.
+
+**Codify the standards**
+Everything built in months one and two gets documented, versioned, and committed to the repository. Prompts are in `/prompts/`. Governance rules are in `.claude/rules/`. The process is in `docs/process.md`. New engineers onboarding can read these documents and understand how the team works with AI.
+
+**Expand coverage**
+Use AI test generation against the backlog of untested user stories. Measure coverage before and after. Present the delta to leadership as a concrete quality improvement metric.
+
+**Run a retrospective**
+What worked, what didn't, what would the team change. Iterate on the prompts and the process based on real feedback. This is where the prompt library starts to improve -- not from theory but from practice.
+
+**Success at day 90:** The AI practices are self-sustaining. New features get AI-assisted test coverage automatically. Failures get AI-assisted diagnosis automatically. The team ships faster with higher confidence.
+
+---
+
+## Addressing the Quality Concern
+
+Leaders are right to be skeptical. Here is how to address it directly:
+
+**The human gate never goes away.** Every AI output -- test cases, failure analysis, release summaries -- is reviewed by a human before it acts on the codebase. AI accelerates the work; humans hold the quality bar.
+
+**Measure before and after.** Establish baseline metrics before introducing AI: test coverage percentage, mean time to diagnose a failure, time from PR open to merge, defect escape rate. Measure the same metrics at day 30, 60, and 90. Present the data. If quality is not improving, the strategy gets adjusted.
+
+**Start with the low-risk work.** Test generation for well-understood features, failure analysis for known patterns, release notes from commit history. These are places where the cost of an AI mistake is low and the benefit is high. Do not start with AI making decisions about production releases.
+
+**The prompt library is the quality control mechanism.** A team where every engineer prompts differently produces inconsistent results. A team with a shared, versioned, reviewed prompt library produces consistent results. The library is not a constraint -- it is a quality system.
+
+---
+
+## The Governance Model
+
+Governance is what separates teams that get lasting value from AI from teams that get a short burst of productivity followed by chaos.
+
+The governance model has four components:
+
+**1. The prompt library**
+Every repeatable AI interaction is documented as a versioned prompt with purpose, example input, example output, and a changelog. Prompts are treated like code -- reviewed, tested against real inputs, and improved over time.
+
+**2. The rules layer**
+Project-specific AI behavior rules live in `.claude/rules/` and are read automatically by AI coding assistants. Testing standards, API conventions, code style -- these are enforced automatically rather than repeated in every prompt.
+
+**3. The review gate**
+AI outputs are never merged without human review. This is non-negotiable. The CI pipeline enforces it: branch protection requires tests to pass, and tests are reviewed before they are added to the suite.
+
+**4. The diary and reflection loop**
+Teams improve by reflecting on what they build. Session logs capture what was built, what decisions were made, and what the team learned. Regular reflection updates the governance rules based on real experience.
+
+---
+
+## What This Looks Like in Practice
+
+I built this strategy while building Session Zero -- a full-stack application I conceived, deployed, and maintain at somanygames.app. The AI governance layer described above is not theoretical. It exists in the repository:
+
+- `/prompts/` -- versioned prompt library with documented inputs, outputs, and changelogs
+- `.claude/rules/testing.md` -- codified QA standards auto-enforced on every test file
+- `.claude/commands/` -- slash commands that encode project standards into the workflow
+- `CLAUDE.md` -- project context that every AI coding session starts from
+- `docs/process.md` -- the complete engineering process documented for reproducibility
+- `docs/diary.md` -- session logs capturing decisions and learnings over time
+
+When Playwright tests fail in CI, the failure output is automatically piped to Claude for root cause analysis. The report is uploaded as an artifact and printed to the CI logs. That is AI integrated into the QA pipeline -- not as a demo, but as a production system running on real failures.
+
+This is what I would build for your team.
+
+---
+
+## ROI Framework
+
+For leadership conversations, frame the value in three categories:
+
+**Speed** -- AI-assisted test generation reduces the time to write a test case by 60-80%. Failure analysis reduces diagnosis time from hours to minutes. Release summaries eliminate a manual artifact that previously took 30-60 minutes per release.
+
+**Coverage** -- Teams consistently leave untested user stories in the backlog because writing tests is slow. AI generation removes that bottleneck. Coverage increases not because engineers work more hours but because the cost per test drops.
+
+**Consistency** -- The most expensive QA problems come from inconsistency: flaky tests, missed edge cases, undocumented assumptions. A shared prompt library and governance layer reduces inconsistency across the team regardless of individual skill level.
+
+---
+
+## Risk Management
+
+**Risk: AI-generated tests that pass but don't validate the right thing**
+Mitigation: All AI-generated tests are reviewed by a human engineer before merging. The review checklist includes: does this test validate behavior or implementation? Would this test catch a real regression?
+
+**Risk: Prompt drift -- engineers modifying prompts without review**
+Mitigation: Prompts are version-controlled and changes go through PR review, the same as code.
+
+**Risk: Over-reliance -- engineers stop thinking critically about test quality**
+Mitigation: AI proposes, humans decide. The governance model makes this explicit. Regular retrospectives surface drift before it becomes a problem.
+
+**Risk: Moving too fast and disrupting what works**
+Mitigation: The 90-day plan is deliberately phased. Month one introduces no new tools -- only standardization of what exists. Tools are introduced only after the foundation is in place.
+
+---
+
+*Paul Luedke -- QA Engineering Leader*
+*somanygames.app -- live portfolio project*
+*github.com/pwluedke/session-zero -- full source*
+
+---

--- a/docs/diary.md
+++ b/docs/diary.md
@@ -32,3 +32,41 @@ Read at the start of every session using /reflect.
 - PR descriptions reference issue numbers with "Closes #n" -- keep this pattern, it auto-closes issues on merge.
 
 ---
+
+## 2026-04-18
+
+### Completed
+- PR #125 merged (previous session): Fix BGG badge linking to Google search instead of BGG (#124). Added case-insensitive name-matching in `mergeBGGGames()` to backfill `bggId` on manual games during sync.
+- PR #127 merged (previous session): Migrate Settings from localStorage to Postgres (#109). Added `settings` table, `GET/PUT /api/settings` routes, `initSettings()` in app.js, settings mock in Playwright `beforeEach`.
+- PR #128 opened: Migrate Game Library from localStorage to Postgres (#110). Full games CRUD API (`GET`, `POST`, `PUT`, `DELETE`, `POST /api/games/sync`), write-through caching in app.js, import prompt for existing localStorage data, `library.seedGames()` Page Object helper, 3 new import prompt tests, `DEFAULT_TEST_GAMES` constant replaces games.json dependency in tests.
+- PR #129 opened: Migrate Play History and Active Sessions to Postgres (#111). Added `sessions`, `session_players` (with feedback columns), and `active_sessions` (JSONB) tables. Seven new API routes. Import prompts for both `sz-history` and `sz-active-sessions`. 10 new tests: finalize flow, pause, resume, empty state, 6 import prompt tests. Total test count: 61.
+- Issue #130 created: PWA support -- add to home screen on mobile.
+- PR #131 opened: Add `docs/ai-strategy.md` (QA AI strategy document, no code changes).
+
+### Decisions made
+- Game library: write-through caching pattern (optimistic in-memory update + fire-and-forget API). Same pattern used for all subsequent migrations.
+- Game library: no `games.json` fallback for new users -- empty library is acceptable. Tests supply games via `DEFAULT_TEST_GAMES` mock.
+- History schema: denormalized `game_name TEXT NOT NULL` alongside nullable `game_id FK` so history entries survive game deletion.
+- Active sessions: stored as JSONB blob (`data JSONB`) rather than normalized columns -- it's a serialized state snapshot, not a queryable table.
+- History schema: added `mode`, `outcome`, `low_score_wins` columns and per-player feedback columns (`feedback_rating`, `feedback_play_again`, `feedback_notes`) that the issue spec omitted.
+- Import prompts: all four data types (vault, games, history, active sessions) follow the same pattern -- prompt appears if API returns empty and localStorage key exists.
+- `POST /api/history/sync` added for bulk history import (same pattern as `POST /api/games/sync`).
+
+### In progress
+- PR #128 open (feature/game-library-db): Game Library migration, Closes #110.
+- PR #129 open (feature/history-db): History + Active Sessions migration, Closes #111.
+- PR #131 open (docs/ai-strategy): docs only, no tests required.
+
+### Up next
+- Merge PRs #128, #129, #131 after review.
+- Plan and implement #130 (PWA support): manifest.json, service worker, iOS/Android meta tags.
+- Run /reflect at the start of next session.
+
+### Notes
+- The localStorage migration sequence (#108 through #111) is now complete. All four data types persist in Postgres.
+- `beforeEach` in app.spec.js now mocks four APIs: `/api/players`, `/api/games`, `/api/history`, `/api/sessions/active`. All are stateful within each test via closure variables.
+- `library.seedGames()` and `history.seedHistory()` use LIFO Playwright route registration to override the `beforeEach` default -- a pattern to follow for any future seeding needs.
+- `scoreMode` defaults to `'points'` in app.js (not `'winlose'`), so `session.finalize()` can click End Game without selecting an outcome first. Important for tests.
+- The `req.user` undefined errors in server logs during tests are pre-existing (settings route hits real server in test mode) -- not caused by this session's work.
+
+---


### PR DESCRIPTION
## Summary
- Adds `docs/ai-strategy.md`: a practical guide for introducing AI into a QA organization

## Test plan
- [ ] No code changes; existing tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)