### PR TITLE
Fix logout session persistence and Google account picker

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -24,7 +24,7 @@ router.get("/auth/google", (req, res, next) => {
   if (!process.env.GOOGLE_CLIENT_ID) {
     return res.status(503).json({ error: "OAuth not configured" });
   }
-  passport.authenticate("google", { scope: ["profile", "email"] })(req, res, next);
+  passport.authenticate("google", { scope: ["profile", "email"], prompt: "select_account" })(req, res, next);
 });
 
 router.get(
@@ -38,7 +38,9 @@ router.get(
 
 router.get("/auth/logout", (req, res) => {
   req.logout(() => {
-    res.redirect("/login");
+    req.session.destroy(() => {
+      res.redirect("/login");
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

Two bugs found during manual testing of #139.

**Bug 1 - Logout loops back to /pending:** `req.session.destroy()` was never called, leaving the session intact after logout. Signing out from `/pending` re-authenticated immediately and returned to `/pending`. Fixed by calling `req.session.destroy()` inside the `req.logout()` callback before redirecting.

**Bug 2 - Google auto-selects last account:** No `prompt` option was set on the OAuth strategy, so Google silently reused the last signed-in account. Made it impossible to switch accounts without clearing browser data. Fixed by adding `prompt: "select_account"` to the `passport.authenticate` call.

## Test plan

- [x] All 62 Playwright tests pass
- [x] Manual: sign out from /pending - should land on /login with a clean session
- [x] Manual: click "Sign in with Google" - should always show the account chooser

🤖 Generated with [Claude Code](https://claude.com/claude-code)