### PR TITLE
Fix complexity filter and display to use BGG's 5-point weight scale

### DIFF
--- a/app.js
+++ b/app.js
@@ -948,7 +948,7 @@ function renderResults(picked, heading) {
   const filters = getFilters();
 
   picked.forEach((game, index) => {
-    const badgeClass = `badge-${game.complexity.toLowerCase()}`;
+    const badgeClass = `badge-${game.complexity.toLowerCase().replace(/ /g, '-')}`;
     const playerCount = game.minPlayers === game.maxPlayers
       ? `${game.minPlayers} player${game.minPlayers > 1 ? "s" : ""}`
       : `${game.minPlayers}–${game.maxPlayers} players`;
@@ -1958,7 +1958,7 @@ let librarySortDir = 1;   // 1 = asc, -1 = desc
 let libraryDisplayed = []; // { game, idx } — maps display rows back to games[]
 
 const GAME_TYPES       = ['Abstract','Board','Card','Dice','Mystery','Narrative','Party'];
-const GAME_COMPLEXITIES = ['Low','Medium','High'];
+const GAME_COMPLEXITIES = ['Light','Medium Light','Medium','Medium Heavy','Heavy'];
 
 function openLibrary() {
   renderLibrary();
@@ -2050,7 +2050,7 @@ function renderLibrary() {
         <div class="lib-controls">
           <div class="lib-rating">${stars}</div>
           <button class="lib-tag lib-type-tag" onclick="cycleGameField(${di},'type')" title="Click to change type">${game.type}</button>
-          <button class="lib-tag lib-complexity-tag lib-complexity-${(game.complexity||'Medium').toLowerCase()}" onclick="cycleGameField(${di},'complexity')" title="Click to change complexity">${game.complexity}</button>
+          <button class="lib-tag lib-complexity-tag lib-complexity-${(game.complexity||'Medium').toLowerCase().replace(/ /g, '-')}" onclick="cycleGameField(${di},'complexity')" title="Click to change complexity">${game.complexity}</button>
           <button class="lib-toggle${game.cooperative ? ' on' : ''}" onclick="toggleGameField(${di},'cooperative')">Co-op</button>
           <button class="lib-toggle${game.played ? ' on' : ''}" onclick="toggleGameField(${di},'played')">Played</button>
           ${spotifyBadge}${bggLink}

--- a/index.html
+++ b/index.html
@@ -98,9 +98,11 @@
           <label for="complexity">Complexity</label>
           <select id="complexity" data-testid="filter-complexity">
             <option value="">Any</option>
-            <option value="Low">Low</option>
+            <option value="Light">Light</option>
+            <option value="Medium Light">Medium Light</option>
             <option value="Medium">Medium</option>
-            <option value="High">High</option>
+            <option value="Medium Heavy">Medium Heavy</option>
+            <option value="Heavy">Heavy</option>
           </select>
         </div>
       </div>
@@ -432,9 +434,11 @@
             <option value="Narrative">Narrative</option>
           </select>
           <select id="ag-complexity" data-testid="ag-complexity">
-            <option value="Low">Low</option>
+            <option value="Light">Light</option>
+            <option value="Medium Light">Medium Light</option>
             <option value="Medium" selected>Medium</option>
-            <option value="High">High</option>
+            <option value="Medium Heavy">Medium Heavy</option>
+            <option value="Heavy">Heavy</option>
           </select>
           <input type="number" id="ag-min-players" data-testid="ag-min-players" min="1" max="20" placeholder="Min players" />
           <input type="number" id="ag-max-players" data-testid="ag-max-players" min="1" max="20" placeholder="Max players" />

--- a/routes/api.js
+++ b/routes/api.js
@@ -583,6 +583,19 @@ function parseBGGXml(xml) {
     const playsMatch = block.match(/<numplays>(\d+)<\/numplays>/);
     const played = playsMatch ? parseInt(playsMatch[1]) > 0 : false;
 
+    const weightMatch = block.match(/<averageweight\s+value="([^"]*)"/);
+    let complexity = "Medium";
+    if (weightMatch && weightMatch[1] !== "0") {
+      const w = parseFloat(weightMatch[1]);
+      if (!isNaN(w) && w > 0) {
+        if      (w < 2.0) complexity = "Light";
+        else if (w < 2.5) complexity = "Medium Light";
+        else if (w < 3.5) complexity = "Medium";
+        else if (w < 4.0) complexity = "Medium Heavy";
+        else              complexity = "Heavy";
+      }
+    }
+
     const playTime = maxPlaytime || minPlaytime || 60;
 
     games.push({
@@ -590,7 +603,7 @@ function parseBGGXml(xml) {
       minPlayers,
       maxPlayers,
       playTime: playTime >= 999 ? 999 : playTime,
-      complexity: "Medium",
+      complexity,
       type: "Board",
       age: 0,
       setupTime: 10,

--- a/style.css
+++ b/style.css
@@ -354,9 +354,11 @@ button:hover {
   white-space: nowrap;
 }
 
-.badge-low    { background: #1e4d2b; color: #5dd67a; }
-.badge-medium { background: #4d3a1a; color: #f5a842; }
-.badge-high   { background: #4d1a1a; color: #f55252; }
+.badge-light        { background: #1e4d2b; color: #5dd67a; }
+.badge-medium-light { background: #2a4d1e; color: #8fd66a; }
+.badge-medium       { background: #4d3a1a; color: #f5a842; }
+.badge-medium-heavy { background: #4d2a1a; color: #f57842; }
+.badge-heavy        { background: #4d1a1a; color: #f55252; }
 
 .game-rating {
   font-size: 0.8rem;
@@ -2570,9 +2572,11 @@ body.hide-why .why-btn {
 
 .lib-tag:hover { border-color: #f5c842; color: #f5c842; }
 
-.lib-complexity-low    { border-color: #5dd67a; color: #5dd67a; }
-.lib-complexity-medium { border-color: #f5c842; color: #f5c842; }
-.lib-complexity-high   { border-color: #e05252; color: #e05252; }
+.lib-complexity-light        { border-color: #5dd67a; color: #5dd67a; }
+.lib-complexity-medium-light { border-color: #8fd66a; color: #8fd66a; }
+.lib-complexity-medium       { border-color: #f5c842; color: #f5c842; }
+.lib-complexity-medium-heavy { border-color: #f59042; color: #f59042; }
+.lib-complexity-heavy        { border-color: #e05252; color: #e05252; }
 
 .lib-toggle {
   font-size: 0.68rem;

--- a/tests/app.spec.js
+++ b/tests/app.spec.js
@@ -22,13 +22,15 @@ const MOCK_PLAYLISTS = {
 };
 
 // Default game library used by the /api/games mock in beforeEach.
-// Includes Low-complexity games (for filter tests) and Wingspan Asia (for 'wing' search test).
+// Covers all 5 complexity values to support filter tests and badge tests.
 const DEFAULT_TEST_GAMES = [
-  { id: 1, name: 'Wingspan Asia', type: 'Board', complexity: 'Medium', minPlayers: 1, maxPlayers: 2, playTime: 70, age: 14, setupTime: 10, rating: null, played: false, cooperative: false, thumbnail: null, bggId: 366161, source: 'bgg', spotifyEmbedUrl: null, spotifyPlaylistName: null },
-  { id: 2, name: 'Azul', type: 'Board', complexity: 'Medium', minPlayers: 2, maxPlayers: 4, playTime: 45, age: 8, setupTime: 5, rating: null, played: true, cooperative: false, thumbnail: null, bggId: 230802, source: 'bgg', spotifyEmbedUrl: null, spotifyPlaylistName: null },
-  { id: 3, name: 'Catan', type: 'Board', complexity: 'Medium', minPlayers: 3, maxPlayers: 6, playTime: 90, age: 10, setupTime: 10, rating: null, played: true, cooperative: false, thumbnail: null, bggId: 13, source: 'bgg', spotifyEmbedUrl: null, spotifyPlaylistName: null },
-  { id: 4, name: 'Codenames', type: 'Party', complexity: 'Low', minPlayers: 2, maxPlayers: 8, playTime: 15, age: 14, setupTime: 2, rating: null, played: true, cooperative: false, thumbnail: null, bggId: 178900, source: 'bgg', spotifyEmbedUrl: null, spotifyPlaylistName: null },
-  { id: 5, name: 'Fluxx', type: 'Card', complexity: 'Low', minPlayers: 2, maxPlayers: 6, playTime: 30, age: 8, setupTime: 1, rating: null, played: true, cooperative: false, thumbnail: null, bggId: 258, source: 'bgg', spotifyEmbedUrl: null, spotifyPlaylistName: null },
+  { id: 1, name: 'Wingspan Asia',   type: 'Board', complexity: 'Medium',       minPlayers: 1, maxPlayers: 2, playTime: 70, age: 14, setupTime: 10, rating: null, played: false, cooperative: false, thumbnail: null, bggId: 366161, source: 'bgg', spotifyEmbedUrl: null, spotifyPlaylistName: null },
+  { id: 2, name: 'Azul',            type: 'Board', complexity: 'Medium Light', minPlayers: 2, maxPlayers: 4, playTime: 45, age: 8,  setupTime: 5,  rating: null, played: true,  cooperative: false, thumbnail: null, bggId: 230802, source: 'bgg', spotifyEmbedUrl: null, spotifyPlaylistName: null },
+  { id: 3, name: 'Catan',           type: 'Board', complexity: 'Medium',       minPlayers: 3, maxPlayers: 6, playTime: 90, age: 10, setupTime: 10, rating: null, played: true,  cooperative: false, thumbnail: null, bggId: 13,     source: 'bgg', spotifyEmbedUrl: null, spotifyPlaylistName: null },
+  { id: 4, name: 'Codenames',       type: 'Party', complexity: 'Light',        minPlayers: 2, maxPlayers: 8, playTime: 15, age: 14, setupTime: 2,  rating: null, played: true,  cooperative: false, thumbnail: null, bggId: 178900, source: 'bgg', spotifyEmbedUrl: null, spotifyPlaylistName: null },
+  { id: 5, name: 'Fluxx',           type: 'Card',  complexity: 'Light',        minPlayers: 2, maxPlayers: 6, playTime: 30, age: 8,  setupTime: 1,  rating: null, played: true,  cooperative: false, thumbnail: null, bggId: 258,    source: 'bgg', spotifyEmbedUrl: null, spotifyPlaylistName: null },
+  { id: 6, name: 'Terraforming Mars', type: 'Board', complexity: 'Medium Heavy', minPlayers: 1, maxPlayers: 5, playTime: 120, age: 12, setupTime: 15, rating: null, played: true, cooperative: false, thumbnail: null, bggId: 167791, source: 'bgg', spotifyEmbedUrl: null, spotifyPlaylistName: null },
+  { id: 7, name: 'Spirit Island',   type: 'Board', complexity: 'Heavy',        minPlayers: 1, maxPlayers: 4, playTime: 120, age: 14, setupTime: 20, rating: null, played: true,  cooperative: true,  thumbnail: null, bggId: 162886, source: 'bgg', spotifyEmbedUrl: null, spotifyPlaylistName: null },
 ];
 
 // Each test gets a fresh localStorage so state doesn't bleed between runs.
@@ -269,12 +271,12 @@ test('filtering by player count narrows results', async ({ page }) => {
 
 test('filtering by complexity narrows results and all badges match', async ({ page }) => {
   const main = new MainPage(page);
-  await main.setComplexity('Low');
+  await main.setComplexity('Light');
   await main.findGames();
   await main.expectResults();
   const count = await main.gameCards().count();
   expect(count).toBeGreaterThan(0);
-  const badges = await page.locator('[data-testid="game-list"] .badge-low').count();
+  const badges = await page.locator('[data-testid="game-list"] .badge-light').count();
   expect(badges).toBe(count);
 });
 
@@ -316,7 +318,7 @@ test('expanded game card shows BGG badge linking to boardgamegeek.com for a BGG 
 
   await library.seedGames([
     { id: 101, name: 'Ticket to Ride', minPlayers: 2, maxPlayers: 5, playTime: 60,
-      complexity: 'Low', type: 'Board', age: 8, setupTime: 10, rating: 4,
+      complexity: 'Light', type: 'Board', age: 8, setupTime: 10, rating: 4,
       played: false, cooperative: false, thumbnail: null, bggId: 9209, source: 'bgg',
       spotifyEmbedUrl: null, spotifyPlaylistName: null },
   ]);
@@ -336,7 +338,7 @@ test('expanded game card shows BGG badge linking to Google search for a manual g
 
   await library.seedGames([
     { id: 102, name: 'My Homebrew Game', minPlayers: 2, maxPlayers: 4, playTime: 30,
-      complexity: 'Low', type: 'Card', age: 0, setupTime: 5, rating: null,
+      complexity: 'Light', type: 'Card', age: 0, setupTime: 5, rating: null,
       played: false, cooperative: false, thumbnail: null, bggId: null, source: 'manual',
       spotifyEmbedUrl: null, spotifyPlaylistName: null },
   ]);
@@ -453,7 +455,7 @@ test('BGG sync preserves manually added games not in BGG response', async ({ pag
 
   await library.seedGames([
     { id: 201, name: 'My Homebrew Game', minPlayers: 2, maxPlayers: 4, playTime: 30,
-      complexity: 'Low', type: 'Card', age: 0, setupTime: 5, rating: null,
+      complexity: 'Light', type: 'Card', age: 0, setupTime: 5, rating: null,
       played: false, cooperative: false, thumbnail: null, bggId: null, source: 'manual',
       spotifyEmbedUrl: null, spotifyPlaylistName: null },
   ]);
@@ -509,7 +511,7 @@ test('BGG sync adds new games from BGG not yet in the local library', async ({ p
       contentType: 'application/json',
       body: JSON.stringify({
         games: [{ name: 'Brand New Game', minPlayers: 2, maxPlayers: 4, playTime: 45,
-                  complexity: 'Low', type: 'Board', age: 8, setupTime: 5,
+                  complexity: 'Light', type: 'Board', age: 8, setupTime: 5,
                   rating: null, played: false, cooperative: false, thumbnail: null, bggId: 99999 }],
         count: 1,
       }),
@@ -529,7 +531,7 @@ test('BGG sync backfills bggId on a name-matched manual game so badge links to B
 
   await library.seedGames([
     { id: 204, name: 'Ticket to Ride', minPlayers: 2, maxPlayers: 5, playTime: 60,
-      complexity: 'Low', type: 'Board', age: 8, setupTime: 10, rating: 4,
+      complexity: 'Light', type: 'Board', age: 8, setupTime: 10, rating: 4,
       played: false, cooperative: false, thumbnail: null, bggId: null, source: 'manual',
       spotifyEmbedUrl: null, spotifyPlaylistName: null },
   ]);
@@ -539,7 +541,7 @@ test('BGG sync backfills bggId on a name-matched manual game so badge links to B
       contentType: 'application/json',
       body: JSON.stringify({
         games: [{ name: 'Ticket to Ride', minPlayers: 2, maxPlayers: 5, playTime: 60,
-                  complexity: 'Low', type: 'Board', age: 8, setupTime: 10,
+                  complexity: 'Light', type: 'Board', age: 8, setupTime: 10,
                   rating: null, played: false, cooperative: false, thumbnail: null, bggId: 9209 }],
         count: 1,
       }),
@@ -599,7 +601,7 @@ test('import prompt appears when localStorage has games and API returns empty li
   await page.evaluate(() => {
     localStorage.setItem('sz-games', JSON.stringify([
       { name: 'Old Game', minPlayers: 2, maxPlayers: 4, playTime: 30,
-        complexity: 'Low', type: 'Card', age: 0, setupTime: 5,
+        complexity: 'Light', type: 'Card', age: 0, setupTime: 5,
         rating: null, played: false, cooperative: false, thumbnail: null,
         bggId: null, source: 'manual' },
     ]));
@@ -623,7 +625,7 @@ test('importing local games calls sync endpoint and dismisses prompt', async ({ 
     if (method === 'POST' && url.includes('/sync')) {
       syncCalled = true;
       return route.fulfill({ contentType: 'application/json', body: JSON.stringify([
-        { id: 1, name: 'Old Game', type: 'Card', complexity: 'Low', minPlayers: 2, maxPlayers: 4,
+        { id: 1, name: 'Old Game', type: 'Card', complexity: 'Light', minPlayers: 2, maxPlayers: 4,
           playTime: 30, age: 0, setupTime: 5, rating: null, played: false, cooperative: false,
           thumbnail: null, bggId: null, source: 'manual', spotifyEmbedUrl: null, spotifyPlaylistName: null },
       ]) });
@@ -633,7 +635,7 @@ test('importing local games calls sync endpoint and dismisses prompt', async ({ 
   await page.evaluate(() => {
     localStorage.setItem('sz-games', JSON.stringify([
       { name: 'Old Game', minPlayers: 2, maxPlayers: 4, playTime: 30,
-        complexity: 'Low', type: 'Card', age: 0, setupTime: 5,
+        complexity: 'Light', type: 'Card', age: 0, setupTime: 5,
         rating: null, played: false, cooperative: false, thumbnail: null,
         bggId: null, source: 'manual' },
     ]));
@@ -661,7 +663,7 @@ test('dismissing import prompt removes localStorage entry', async ({ page }) => 
   await page.evaluate(() => {
     localStorage.setItem('sz-games', JSON.stringify([
       { name: 'Old Game', minPlayers: 2, maxPlayers: 4, playTime: 30,
-        complexity: 'Low', type: 'Card', age: 0, setupTime: 5,
+        complexity: 'Light', type: 'Card', age: 0, setupTime: 5,
         rating: null, played: false, cooperative: false, thumbnail: null,
         bggId: null, source: 'manual' },
     ]));


### PR DESCRIPTION
## Summary
- BGG sync now parses `<averageweight>` from the XML response and maps the float value to the correct label using these thresholds: < 2.0 Light, 2.0-2.5 Medium Light, 2.5-3.5 Medium, 3.5-4.0 Medium Heavy, >= 4.0 Heavy
- Previously every synced game was hardcoded to `"Medium"`
- Filter dropdown and Add Game dropdown updated from 3 options to 5
- `GAME_COMPLEXITIES` array expanded for the library complexity cycle button
- Badge CSS class generation now replaces spaces with dashes (`badge-medium-light`, `badge-medium-heavy`)
- Two new CSS classes added for badges and library tags in `style.css`
- `DEFAULT_TEST_GAMES` in tests updated to cover all 5 complexity values; old `'Low'` values replaced with `'Light'`

## Test plan
- [x] 74/74 existing tests pass
- [x] Filtering by Light returns only Light games with `.badge-light` badges
- [x] Existing games show "Medium" until re-synced (no migration needed)

Closes #134