### PR TITLE
Fix pg DATE columns returning as JS Date objects

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -1,4 +1,9 @@
-const { Pool } = require("pg");
+const { Pool, types } = require("pg");
+
+// pg returns DATE columns as JS Date objects by default.
+// String(dateObj).split('T')[0] splits on the 'T' in "GMT", not the date/time boundary.
+// Return DATE values as plain 'YYYY-MM-DD' strings instead.
+types.setTypeParser(1082, val => val);
 
 let pool = null;
 


### PR DESCRIPTION
## Summary

- `db/index.js`: register a pg type parser (OID 1082) so DATE columns return as plain `'YYYY-MM-DD'` strings instead of JS Date objects

## Root cause

pg parses DATE columns into JS Date objects by default. The history normalizer in `routes/api.js` does `String(row.played_at).split('T')[0]` to extract the date, but `String(new Date(...))` produces something like `"Wed Apr 22 2026 00:00:00 GMT-0500 (CDT)"`. Splitting on `'T'` hits the `T` in `"GMT"` instead of the date/time boundary, producing `"Wed Apr 22 2026 00:00:00 GM"`. The history card then renders dates as garbage (or Invalid Date) in the browser.

## Test plan

- [x] Run `node scripts/seed-dev.js` then open the app and verify History modal shows correct dates on all session cards
- [x] Confirm existing Playwright tests pass

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)