### PR TITLE
Add /merged slash command for post-merge local sync

### DIFF
--- a/.claude/commands/merged.md
+++ b/.claude/commands/merged.md
@@ -1,0 +1,40 @@
+# /merged
+Post-merge local sync. Run after a PR merges on GitHub.
+
+Usage: `/merged <PR number>`
+
+## Step 1 -- Verify the PR is merged
+Run:
+```bash
+gh pr view $ARGUMENTS --json state,mergedAt,headRefName
+```
+If `state` is not `MERGED`, stop and report. Do not proceed.
+
+Capture `headRefName` -- this is the feature branch to delete.
+
+## Step 2 -- Sync main
+Run:
+```bash
+git checkout main
+git pull
+```
+
+## Step 3 -- Delete the local feature branch
+Run:
+```bash
+git branch -d <headRefName>
+```
+If the delete fails for any reason, stop and report the error. Do not use `-D` (force delete) without explicit user confirmation.
+
+## Step 4 -- Confirm clean state
+Run:
+```bash
+git status
+```
+Confirm the working tree is clean.
+
+## Step 5 -- Report
+Output a single summary:
+- PR number merged
+- Branch deleted
+- main is now at `<short SHA>` (via `git rev-parse --short HEAD`)

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -27,3 +27,7 @@ State one of:
 - QUESTION -- something needs clarification before a verdict
 
 Never approve a PR that fails Pass 1. A well-written PR that doesn't meet the spec is not done.
+
+After both passes complete, end your output with:
+"PR #N is open. After you merge it on GitHub, run `/merged N` to sync locally."
+Use the actual PR number obtained via `gh pr view --json number`.


### PR DESCRIPTION
## Summary
- Adds `.claude/commands/merged.md` -- a new slash command that automates post-merge local sync (verify merged, checkout main, pull, delete feature branch, confirm clean state)
- Appends a `/merged` reminder to `.claude/commands/review.md` so the prompt surfaces at the natural moment after a review completes

## Test plan
- [ ] Invoke `/merged <PR number>` on a merged PR and confirm it runs all 5 steps in order
- [ ] Invoke `/merged <PR number>` on an open PR and confirm it stops at Step 1 without touching git state
- [ ] Confirm `/review` output now ends with the `/merged N` reminder

Closes #171